### PR TITLE
NCS-423 Extra logging in eligibility controller and company profile service

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/contoller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/contoller/EligibilityController.java
@@ -30,10 +30,10 @@ public class EligibilityController {
         try {
             var companyProfile =
                     companyProfileService.getCompanyProfile(companyNumber);
-           var companyValidationResponse =
+            var companyValidationResponse =
                     eligibilityService.checkCompanyEligibility(companyProfile);
 
-            if(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE
+            if (EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE
                     == companyValidationResponse.getEligibilityStatusCode()) {
                 return ResponseEntity.ok().body(companyValidationResponse);
             } else {
@@ -44,9 +44,8 @@ public class EligibilityController {
             companyNotFoundResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_NOT_FOUND);
             return ResponseEntity.badRequest().body(companyNotFoundResponse);
         } catch (Exception e) {
-            LOGGER.error("Error checking eligibility of company", e);
+            LOGGER.error(String.format("Error checking eligibility of company number %s", companyNumber), e);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication;
 
@@ -18,7 +17,7 @@ public class LoggingInterceptor implements HandlerInterceptor{
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingInterceptor.class);
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         Long startTime = System.currentTimeMillis();
         request.getSession().setAttribute("start-time", startTime);
 
@@ -31,7 +30,7 @@ public class LoggingInterceptor implements HandlerInterceptor{
     }
 
     @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
         Long startTime = (Long) request.getSession().getAttribute("start-time");
         long responseTime = System.currentTimeMillis() - startTime;
 
@@ -44,8 +43,7 @@ public class LoggingInterceptor implements HandlerInterceptor{
     }
 
     private String requestPath(HttpServletRequest request) {
-        return (String) request
-                .getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        return request.getRequestURI();
     }
 
     private String requestMethod(HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication;
 
@@ -43,7 +44,8 @@ public class LoggingInterceptor implements HandlerInterceptor{
     }
 
     private String requestPath(HttpServletRequest request) {
-        return request.getRequestURI();
+        return (String) request
+                .getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
     }
 
     private String requestMethod(HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CompanyProfileService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CompanyProfileService.java
@@ -13,6 +13,9 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException
 @Service
 public class CompanyProfileService {
 
+    private static final String EXCEPTION_MESSAGE = "Error Retrieving Company Profile for company number %s";
+    private static final String EXCEPTION_MESSAGE_WITH_HTTP_CODE = EXCEPTION_MESSAGE + ", http status code %s";
+
     private final ApiClientService apiClientService;
 
     @Autowired
@@ -25,13 +28,16 @@ public class CompanyProfileService {
             var uri = "/company/" + companyNumber;
             return apiClientService.getApiKeyAuthenticatedClient().company().get(uri).execute().getData();
         } catch (URIValidationException e) {
-            throw new ServiceException("Error Retrieving Company Profile", e);
+            throw new ServiceException(String.format(EXCEPTION_MESSAGE, companyNumber), e);
         } catch (ApiErrorResponseException e) {
             if (HttpStatus.NOT_FOUND.value() == e.getStatusCode()) {
                 throw new CompanyNotFoundException();
             }
-
-            throw new ServiceException("Error Retrieving Company Profile", e);
+            String message = String.format(
+                    EXCEPTION_MESSAGE_WITH_HTTP_CODE,
+                    companyNumber,
+                    e.getStatusCode());
+            throw new ServiceException(message, e);
         }
     }
 }


### PR DESCRIPTION
Changing interceptor logging to log populated endpoint path eg /company/12234567/stuff instead of /company/{companyNumber}/stuff

Making the eligibility controller log the company number on failure