### PR TITLE
NCS-423 Making api calls use new connection for each call to resolve …

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/ApiClientService.java
@@ -10,14 +10,8 @@ import java.io.IOException;
 @Component
 public class ApiClientService {
 
-    private final ApiClient apiKeyAuthenticatedClient;
-
-    public ApiClientService() {
-        apiKeyAuthenticatedClient = ApiSdkManager.getSDK();
-    }
-
     public ApiClient getApiKeyAuthenticatedClient() {
-        return apiKeyAuthenticatedClient;
+        return ApiSdkManager.getSDK();
     }
 
     public ApiClient getOauthAuthenticatedClient(String ericPassThroughHeader) throws IOException {


### PR DESCRIPTION
…bug with apparent connection timeout

Changing the ApiClientService to remove the class level authenticatedClient so we can create a new one for each call which will hopefully resolve the api call bug NCS-423