### PR TITLE
Revert "Bump spring-boot-maven-plugin from 2.4.7 to 2.5.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <spring-boot-dependencies.version>2.4.7</spring-boot-dependencies.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <spring-boot-maven-plugin.version>2.5.2</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>2.4.7</spring-boot-maven-plugin.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
Reverts companieshouse/confirmation-statement-api#69

Plugin org.springframework.boot:spring-boot-maven-plugin:2.5.2 could not find artifact org.tomlj:tomlj:jar:1.0.0 in virtual-release.