### PR TITLE
NCS-409 Removing the org.apache debug logging to allow us to test in …

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,1 @@
 spring.data.mongodb.uri=${MONGODB_URL}/transaction_confirmation_statement_submissions
-
-logging.level.org.apache=DEBUG


### PR DESCRIPTION
…live 
In preparation for a Live test, removing the debug logging for org.apache - Don't want low level connection info shown in live.