### PR TITLE
NCS-242 Adding next made up to date endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/ApplicationConfig.java
@@ -5,11 +5,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
+import java.util.function.Supplier;
+
 @Configuration
 public class ApplicationConfig {
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder.build();
+    }
+
+    @Bean
+    public Supplier<LocalDate> localDateNow() {
+        return LocalDate::now;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
+import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
+
+@RestController
+public class NextMadeUpToDateController {
+
+    @Autowired
+    private ConfirmationStatementService confirmationStatementService;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NextMadeUpToDateController.class);
+
+    @GetMapping("/confirmation-statement/company/{companyNumber}/next-made-up-to-date")
+    public ResponseEntity<NextMadeUpToDateJson> getNextMadeUpToDate(@PathVariable String companyNumber) {
+        try {
+            LOGGER.info("Calling service to retrieve the next made up to date.");
+            NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(companyNumber);
+            return ResponseEntity.ok().body(nextMadeUpToDateJson);
+        } catch( CompanyNotFoundException cnfe) {
+            LOGGER.error(String.format("Unable to find company %s", companyNumber), cnfe);
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            LOGGER.error("Error retrieving next made up to date.", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
@@ -25,7 +25,7 @@ public class NextMadeUpToDateController {
             LOGGER.info("Calling service to retrieve the next made up to date.");
             NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(companyNumber);
             return ResponseEntity.ok().body(nextMadeUpToDateJson);
-        } catch( CompanyNotFoundException cnfe) {
+        } catch(CompanyNotFoundException cnfe) {
             LOGGER.error(String.format("Unable to find company %s", companyNumber), cnfe);
             return ResponseEntity.notFound().build();
         } catch (Exception e) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
@@ -3,15 +3,16 @@ package uk.gov.companieshouse.confirmationstatementapi.model.json;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class NextMadeUpToDateJson {
 
     @JsonProperty("current_next_made_up_to_date")
     private String currentNextMadeUpToDate;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("is_due")
-    private boolean due;
+    private Boolean due;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("new_next_made_up_to_date")
     private String newNextMadeUpToDate;
 
@@ -24,11 +25,11 @@ public class NextMadeUpToDateJson {
         this.currentNextMadeUpToDate = currentNextMadeUpToDate;
     }
 
-    public boolean isDue() {
+    public Boolean isDue() {
         return due;
     }
 
-    public void setDue(boolean due) {
+    public void setDue(Boolean due) {
         this.due = due;
     }
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NextMadeUpToDateJson {
+
+    @JsonProperty("current_next_made_up_to_date")
+    private String currentNextMadeUpToDate;
+
+    @JsonProperty("is_due")
+    private boolean due;
+
+    @JsonProperty("new_next_made_up_to_date")
+    private String newNextMadeUpToDate;
+
+
+    public String getCurrentNextMadeUpToDate() {
+        return currentNextMadeUpToDate;
+    }
+
+    public void setCurrentNextMadeUpToDate(String currentNextMadeUpToDate) {
+        this.currentNextMadeUpToDate = currentNextMadeUpToDate;
+    }
+
+    public boolean isDue() {
+        return due;
+    }
+
+    public void setDue(boolean due) {
+        this.due = due;
+    }
+
+    public String getNewNextMadeUpToDate() {
+        return newNextMadeUpToDate;
+    }
+
+    public void setNewNextMadeUpToDate(String newNextMadeUpToDate) {
+        this.newNextMadeUpToDate = newNextMadeUpToDate;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -200,17 +200,23 @@ public class ConfirmationStatementService {
     public NextMadeUpToDateJson getNextMadeUpToDate(String companyNumber) throws CompanyNotFoundException, ServiceException {
         CompanyProfileApi companyProfileApi = companyProfileService.getCompanyProfile(companyNumber);
 
-        if (companyProfileApi == null
-                || companyProfileApi.getConfirmationStatement() == null
-                || companyProfileApi.getConfirmationStatement().getNextMadeUpTo() == null) {
-            throw new ServiceException(String.format("Unable to read next made up to date from company profile for company %s", companyNumber));
+        if (companyProfileApi == null) {
+            throw new ServiceException(String.format("Unable to find company profile for company %s", companyNumber));
+        }
+
+        NextMadeUpToDateJson nextMadeUpToDateJson = new NextMadeUpToDateJson();
+
+        if (companyProfileApi.getConfirmationStatement() == null
+            || companyProfileApi.getConfirmationStatement().getNextMadeUpTo() == null) {
+                nextMadeUpToDateJson.setCurrentNextMadeUpToDate(null);
+                nextMadeUpToDateJson.setDue(null);
+                nextMadeUpToDateJson.setNewNextMadeUpToDate(null);
+                return nextMadeUpToDateJson;
         }
 
         LocalDate nextMadeUpToDate = companyProfileApi.getConfirmationStatement().getNextMadeUpTo();
-        LocalDate today = localDateNow.get();
-
-        NextMadeUpToDateJson nextMadeUpToDateJson = new NextMadeUpToDateJson();
         nextMadeUpToDateJson.setCurrentNextMadeUpToDate(nextMadeUpToDate.format(DateTimeFormatter.ISO_DATE));
+        LocalDate today = localDateNow.get();
 
         if (today.isBefore(nextMadeUpToDate)) {
             nextMadeUpToDateJson.setDue(false);

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
@@ -1,0 +1,71 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
+import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NextMadeUpToDateControllerTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final NextMadeUpToDateJson NEXT_MADE_UP_TO_DATE_JSON = new NextMadeUpToDateJson();
+
+    @Mock
+    private ConfirmationStatementService confirmationStatementService;
+
+    @InjectMocks
+    private NextMadeUpToDateController nextMadeUpToDateController;
+
+    @BeforeAll
+    static void beforeAll() {
+        NEXT_MADE_UP_TO_DATE_JSON.setDue(false);
+        NEXT_MADE_UP_TO_DATE_JSON.setNewNextMadeUpToDate("2021-06-19");
+        NEXT_MADE_UP_TO_DATE_JSON.setCurrentNextMadeUpToDate("2021-07-21");
+    }
+
+    @Test
+    void getNextMadeUpToDate() throws CompanyNotFoundException, ServiceException {
+        when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
+                .thenReturn(NEXT_MADE_UP_TO_DATE_JSON);
+
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+
+        assertEquals(NEXT_MADE_UP_TO_DATE_JSON, response.getBody());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void getNextMadeUpToDateReturns404() throws CompanyNotFoundException, ServiceException {
+        when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
+                .thenThrow(new CompanyNotFoundException());
+
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
+    void getNextMadeUpToDateReturns500() throws CompanyNotFoundException, ServiceException {
+        when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
+                .thenThrow(new NullPointerException());
+
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidationTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidationTest.java
@@ -42,7 +42,7 @@ class CompanyShareholderCountValidationTest {
 
     @Test
     @Description("Should not throw exception on company with no shareholders")
-    void validateDoesNotThrowOnZeroShareholders() throws EligibilityException {
+    void validateDoesNotThrowOnZeroShareholders() {
         when(shareholderService.getShareholderCount(COMPANY_NUMBER)).thenReturn(0);
 
         assertDoesNotThrow(() -> validation.validate(profile));

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -356,6 +356,32 @@ class ConfirmationStatementServiceTest {
     }
 
     @Test
+    void getNextMadeUpToDateWhenCompanyProfileConfirmationStatementIsNull() throws CompanyNotFoundException, ServiceException {
+        CompanyProfileApi companyProfileApi = getTestCompanyProfileApi();
+        companyProfileApi.setConfirmationStatement(null);
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
+
+        NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER);
+
+        assertNull(nextMadeUpToDateJson.getCurrentNextMadeUpToDate());
+        assertNull(nextMadeUpToDateJson.isDue());
+        assertNull(nextMadeUpToDateJson.getNewNextMadeUpToDate());
+    }
+
+    @Test
+    void getNextMadeUpToDateWhenCompanyProfileNextMadeUpToDateIsNull() throws CompanyNotFoundException, ServiceException {
+        CompanyProfileApi companyProfileApi = getTestCompanyProfileApi();
+        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(null);
+        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
+
+        NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER);
+
+        assertNull(nextMadeUpToDateJson.getCurrentNextMadeUpToDate());
+        assertNull(nextMadeUpToDateJson.isDue());
+        assertNull(nextMadeUpToDateJson.getNewNextMadeUpToDate());
+    }
+
+    @Test
     void getNextMadeUpToDateThrowsExceptionWhenCompanyProfileNotFound() throws CompanyNotFoundException, ServiceException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new CompanyNotFoundException());
 
@@ -365,24 +391,6 @@ class ConfirmationStatementServiceTest {
     @Test
     void getNextMadeUpToDateThrowsExceptionWhenCompanyProfileIsNull() throws CompanyNotFoundException, ServiceException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(null);
-
-        assertThrows(ServiceException.class, () -> this.confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER));
-    }
-
-    @Test
-    void getNextMadeUpToDateThrowsExceptionWhenCompanyProfileConfirmationStatementIsNull() throws CompanyNotFoundException, ServiceException {
-        CompanyProfileApi companyProfileApi = getTestCompanyProfileApi();
-        companyProfileApi.setConfirmationStatement(null);
-        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
-
-        assertThrows(ServiceException.class, () -> this.confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER));
-    }
-
-    @Test
-    void getNextMadeUpToDateThrowsExceptionWhenCompanyProfileNextMadeUpToDateIsNull() throws CompanyNotFoundException, ServiceException {
-        CompanyProfileApi companyProfileApi = getTestCompanyProfileApi();
-        companyProfileApi.getConfirmationStatement().setNextMadeUpTo(null);
-        when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
 
         assertThrows(ServiceException.class, () -> this.confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER));
     }


### PR DESCRIPTION
Adding a new next-made-up-to endpoint to return the current next made up to date, if it is due or not and if a new date is to be used, it is included as new_next_made_up_to_date.