### PR TITLE
NCS-242 add made up to date to submission

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
@@ -8,6 +8,8 @@ import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.SicCodeD
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapital.StatementOfCapitalDataDao;
 
+import java.time.LocalDate;
+
 public class ConfirmationStatementSubmissionDataDao {
 
     @Field("statement_of_capital_data")
@@ -27,6 +29,9 @@ public class ConfirmationStatementSubmissionDataDao {
 
     @Field("shareholder_data")
     private ShareholderDataDao shareholderData;
+
+    @Field("confirmation_statement_made_up_to_date")
+    private LocalDate madeUpToDate;
 
     public StatementOfCapitalDataDao getStatementOfCapitalData() {
         return statementOfCapitalData;
@@ -74,5 +79,13 @@ public class ConfirmationStatementSubmissionDataDao {
 
     public void setShareholdersData(ShareholderDataDao shareholderDataDao) {
         this.shareholderData = shareholderDataDao;
+    }
+
+    public LocalDate getMadeUpToDate() {
+        return madeUpToDate;
+    }
+
+    public void setMadeUpToDate(LocalDate madeUpToDate) {
+        this.madeUpToDate = madeUpToDate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.json;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveDirectorDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
@@ -8,6 +9,8 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.Sha
 import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCodeDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalDataJson;
+
+import java.time.LocalDate;
 
 public class ConfirmationStatementSubmissionDataJson {
 
@@ -31,6 +34,10 @@ public class ConfirmationStatementSubmissionDataJson {
 
     @JsonProperty("register_locations_data")
     private RegisterLocationsDataJson registerLocationsData;
+
+    @JsonProperty("confirmation_statement_made_up_to_date")
+    @JsonFormat(pattern="yyyy-MM-dd")
+    private LocalDate madeUpToDate;
 
     public StatementOfCapitalDataJson getStatementOfCapitalData() {
         return statementOfCapitalData;
@@ -86,5 +93,13 @@ public class ConfirmationStatementSubmissionDataJson {
 
     public void setRegisterLocationsData(RegisterLocationsDataJson registerLocationsData) {
         this.registerLocationsData = registerLocationsData;
+    }
+
+    public LocalDate getMadeUpToDate() {
+        return madeUpToDate;
+    }
+
+    public void setMadeUpToDate(LocalDate madeUpToDate) {
+        this.madeUpToDate = madeUpToDate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/NextMadeUpToDateJson.java
@@ -1,12 +1,16 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.json;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
 
 public class NextMadeUpToDateJson {
 
     @JsonProperty("current_next_made_up_to_date")
-    private String currentNextMadeUpToDate;
+    @JsonFormat(pattern="yyyy-MM-dd")
+    private LocalDate currentNextMadeUpToDate;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("is_due")
@@ -14,14 +18,15 @@ public class NextMadeUpToDateJson {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("new_next_made_up_to_date")
-    private String newNextMadeUpToDate;
+    @JsonFormat(pattern="yyyy-MM-dd")
+    private LocalDate newNextMadeUpToDate;
 
 
-    public String getCurrentNextMadeUpToDate() {
+    public LocalDate getCurrentNextMadeUpToDate() {
         return currentNextMadeUpToDate;
     }
 
-    public void setCurrentNextMadeUpToDate(String currentNextMadeUpToDate) {
+    public void setCurrentNextMadeUpToDate(LocalDate currentNextMadeUpToDate) {
         this.currentNextMadeUpToDate = currentNextMadeUpToDate;
     }
 
@@ -33,11 +38,11 @@ public class NextMadeUpToDateJson {
         this.due = due;
     }
 
-    public String getNewNextMadeUpToDate() {
+    public LocalDate getNewNextMadeUpToDate() {
         return newNextMadeUpToDate;
     }
 
-    public void setNewNextMadeUpToDate(String newNextMadeUpToDate) {
+    public void setNewNextMadeUpToDate(LocalDate newNextMadeUpToDate) {
         this.newNextMadeUpToDate = newNextMadeUpToDate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/ConfirmationStatementJsonDaoMapper.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/ConfirmationStatementJsonDaoMapper.java
@@ -1,14 +1,29 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.mapping;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
+
+import java.time.LocalDate;
 
 @Component
 @Mapper(componentModel = "spring")
 public interface ConfirmationStatementJsonDaoMapper {
 
+      @Mapping(source = "data.madeUpToDate", target = "data.madeUpToDate", qualifiedByName = "localDate")
       ConfirmationStatementSubmissionJson daoToJson(ConfirmationStatementSubmissionDao confirmationStatementSubmissionDao);
+
+      @Mapping(source = "data.madeUpToDate", target = "data.madeUpToDate", qualifiedByName = "localDate")
       ConfirmationStatementSubmissionDao jsonToDao(ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson);
+
+      @Named("localDate")
+      static LocalDate localDate(LocalDate date) {
+            if (date == null) {
+                  return null;
+            }
+            return LocalDate.of(date.getYear(), date.getMonth(), date.getDayOfMonth());
+      }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
@@ -13,6 +13,9 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException
 import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
@@ -32,8 +35,8 @@ class NextMadeUpToDateControllerTest {
     @BeforeAll
     static void beforeAll() {
         NEXT_MADE_UP_TO_DATE_JSON.setDue(false);
-        NEXT_MADE_UP_TO_DATE_JSON.setNewNextMadeUpToDate("2021-06-19");
-        NEXT_MADE_UP_TO_DATE_JSON.setCurrentNextMadeUpToDate("2021-07-21");
+        NEXT_MADE_UP_TO_DATE_JSON.setNewNextMadeUpToDate(LocalDate.parse("2021-06-19", DateTimeFormatter.ISO_DATE));
+        NEXT_MADE_UP_TO_DATE_JSON.setCurrentNextMadeUpToDate(LocalDate.parse("2021-07-21", DateTimeFormatter.ISO_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
@@ -24,6 +24,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapi
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapperImpl;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,6 +88,8 @@ class JsonDaoMappingTest {
         ShareholderDataDao shareholderDao = dao.getData().getShareholdersData();
         RegisterLocationsDataJson rlJson = json.getData().getRegisterLocationsData();
         RegisterLocationsDataDao rlDao = dao.getData().getRegisterLocationsData();
+        LocalDate madeUpToDateDao = dao.getData().getMadeUpToDate();
+        LocalDate madeUpToDateJson = json.getData().getMadeUpToDate();
 
 
         assertEquals(sicJson.getCode(), sicDao.getCode());
@@ -95,5 +98,6 @@ class JsonDaoMappingTest {
         assertEquals(dirJson.getSectionStatus(), dirDao.getSectionStatus());
         assertEquals(shareholderJson.getSectionStatus(), shareholderDao.getSectionStatus());
         assertEquals(rlJson.getSectionStatus(), rlDao.getSectionStatus());
+        assertEquals(madeUpToDateJson, madeUpToDateDao);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -53,6 +53,7 @@ class ConfirmationStatementServiceTest {
     private static final String PASS_THROUGH = "13456";
     private static final String SUBMISSION_ID = "abcdefg";
     private static final LocalDate NEXT_MADE_UP_TO_DATE = LocalDate.of(2022, 2, 27);
+    private static final String NEXT_MADE_UP_TO_DATE_STRING = NEXT_MADE_UP_TO_DATE.format(DateTimeFormatter.ISO_DATE);
 
     @Mock
     private CompanyProfileService companyProfileService;
@@ -114,7 +115,7 @@ class ConfirmationStatementServiceTest {
         when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(eligibilityResponse);
         when(confirmationStatementSubmissionsRepository.insert(any(ConfirmationStatementSubmissionDao.class))).thenReturn(confirmationStatementSubmission);
         when(confirmationStatementSubmissionsRepository.save(any(ConfirmationStatementSubmissionDao.class))).thenReturn(confirmationStatementSubmission);
-        when(oracleQueryClient.isConfirmationStatementPaid(COMPANY_NUMBER, "2022-01-01")).thenReturn(true);
+        when(oracleQueryClient.isConfirmationStatementPaid(COMPANY_NUMBER, "2021-04-14")).thenReturn(true);
         LocalDate today = LocalDate.of(2021, 04, 14);
         when(localDateSupplier.get()).thenReturn(today);
 
@@ -146,8 +147,8 @@ class ConfirmationStatementServiceTest {
         when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(eligibilityResponse);
         when(confirmationStatementSubmissionsRepository.insert(any(ConfirmationStatementSubmissionDao.class))).thenReturn(confirmationStatementSubmission);
         when(confirmationStatementSubmissionsRepository.save(any(ConfirmationStatementSubmissionDao.class))).thenReturn(confirmationStatementSubmission);
-        when(oracleQueryClient.isConfirmationStatementPaid(COMPANY_NUMBER, "2022-01-01")).thenReturn(false);
-        LocalDate today = LocalDate.of(2021, 04, 14);
+        when(oracleQueryClient.isConfirmationStatementPaid(COMPANY_NUMBER, NEXT_MADE_UP_TO_DATE_STRING)).thenReturn(false);
+        LocalDate today = LocalDate.of(2022, 04, 14);
         when(localDateSupplier.get()).thenReturn(today);
 
         var response = this.confirmationStatementService.createConfirmationStatement(transaction, PASS_THROUGH);
@@ -162,7 +163,7 @@ class ConfirmationStatementServiceTest {
 
         verify(confirmationStatementSubmissionsRepository).save(submissionCaptor.capture());
         var confirmationStatementSubmissionDao = submissionCaptor.getValue();
-        assertEquals(today, confirmationStatementSubmissionDao.getData().getMadeUpToDate());
+        assertEquals(NEXT_MADE_UP_TO_DATE, confirmationStatementSubmissionDao.getData().getMadeUpToDate());
     }
 
     @Test


### PR DESCRIPTION
This is to add the made up to date onto the submission when it gets created. Had to refactor the method that works out the date and switched to use LocalDates in the model instead of Strings.
And passing the madeUpToDate into the payment check.