### PR TITLE
NCS-671 Use UTC timezone as Mongo stores dates and times using UTC ti…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
@@ -3,6 +3,9 @@ package uk.gov.companieshouse.confirmationstatementapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class ConfirmationStatementApiApplication {
 
@@ -12,4 +15,10 @@ public class ConfirmationStatementApiApplication {
 		SpringApplication.run(ConfirmationStatementApiApplication.class, args);
 	}
 
+	@PostConstruct
+	public void init() {
+		// This is to prevent times being out of time by an hour during British Summer Time in MongoDB
+		// MongoDB stores UTC datetime, and LocalDate doesn't contain timezone
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+	}
 }


### PR DESCRIPTION
…mezone - fixes the 1 hour out problem

Bug was raised as the next made up to date stored in mongo was an hour out when sing the date from CHS. Couldn't replicate in Docker, but Mongo uses UTC timezone, so setting the api to use UTC (as we did in Strike-off-objections)