### PR TITLE
Ncs 695 filing endpoint data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -1,22 +1,41 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
+import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
 
 @RestController
 @RequestMapping("/private/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/filings")
 public class FilingController {
 
-    @GetMapping
-    public ResponseEntity<FilingApi> getFiling(@RequestAttribute("transaction") Transaction transaction) {
-        var filing = new FilingApi();
-        filing.setDescription(transaction.getDescription());
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilingController.class);
 
-        return ResponseEntity.ok(filing);
+    @Autowired
+    private FilingService filingService;
+
+    @GetMapping
+    public ResponseEntity<FilingApi> getFiling(@RequestAttribute("transaction") Transaction transaction,
+                                               @PathVariable String confirmationStatementId) {
+        FilingApi filing = null;
+        try {
+            filing = filingService.generateConfirmationFiling(transaction, confirmationStatementId);
+            return ResponseEntity.ok(filing);
+        } catch (SubmissionNotFoundException e) {
+            LOGGER.error(e.getMessage(), e);
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -23,9 +23,8 @@ public class FilingController {
 
     @GetMapping
     public ResponseEntity<FilingApi> getFiling(@PathVariable("confirmation_statement_id") String confirmationStatementId) {
-        FilingApi filing = null;
         try {
-            filing = filingService.generateConfirmationFiling(confirmationStatementId);
+            FilingApi filing = filingService.generateConfirmationFiling(confirmationStatementId);
             return ResponseEntity.ok(filing);
         } catch (SubmissionNotFoundException e) {
             LOGGER.error(e.getMessage(), e);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -6,10 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
@@ -24,11 +22,10 @@ public class FilingController {
     private FilingService filingService;
 
     @GetMapping
-    public ResponseEntity<FilingApi> getFiling(@RequestAttribute("transaction") Transaction transaction,
-                                               @PathVariable String confirmationStatementId) {
+    public ResponseEntity<FilingApi> getFiling(@PathVariable("confirmation_statement_id") String confirmationStatementId) {
         FilingApi filing = null;
         try {
-            filing = filingService.generateConfirmationFiling(transaction, confirmationStatementId);
+            filing = filingService.generateConfirmationFiling(confirmationStatementId);
             return ResponseEntity.ok(filing);
         } catch (SubmissionNotFoundException e) {
             LOGGER.error(e.getMessage(), e);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -216,7 +216,6 @@ public class ConfirmationStatementService {
         }
     }
 
-
     public NextMadeUpToDateJson getNextMadeUpToDate(String companyNumber) throws CompanyNotFoundException, ServiceException {
         CompanyProfileApi companyProfileApi = companyProfileService.getCompanyProfile(companyNumber);
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -31,7 +31,6 @@ public class FilingService {
         FilingApi filing = new FilingApi();
         filing.setKind("Confirmation Statement");
         setFilingApiData(filing, confirmationStatementId);
-        setDescription(filing);
         return filing;
     }
 
@@ -43,19 +42,20 @@ public class FilingService {
                         new SubmissionNotFoundException(
                                 String.format("Empty submission returned when generating filing for %s", confirmationStatementId)));
         if (submission.getData() != null) {
+            LocalDate madeUpToDate = submission.getData().getMadeUpToDate();
             Map<String, Object> data = new HashMap<>();
-            data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
+            data.put("confirmationStatementDate", madeUpToDate );
             data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
             data.put("dtr5Ind", false);
             filing.setData(data);
+            setDescription(filing, madeUpToDate);
         } else {
             throw new SubmissionNotFoundException(
                     String.format("Submission contains no data %s", confirmationStatementId));
         }
     }
 
-    private void setDescription(FilingApi filing) {
-        LocalDate madeUpToDate = (LocalDate)filing.getData().get("confirmationStatementDate");
+    private void setDescription(FilingApi filing, LocalDate madeUpToDate) {
         String madeUpToDateStr = madeUpToDate.format(formatter);
         filing.setDescriptionIdentifier(filingDescription);
         filing.setDescription(filingDescription.replace("{made up date}", madeUpToDateStr));

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class FilingService {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private ConfirmationStatementService confirmationStatementService;
+    private Environment environment;
+
+    @Autowired
+    public FilingService(ConfirmationStatementService csService, Environment env) {
+        confirmationStatementService = csService;
+        environment = env;
+    }
+
+    public FilingApi generateConfirmationFiling(Transaction transaction, String confirmationStatementId) throws SubmissionNotFoundException {
+        FilingApi filing = new FilingApi();
+        filing.setKind("CS01");
+        setFilingApiData(filing, confirmationStatementId);
+        setDescription(filing);
+        return filing;
+    }
+
+    private void setFilingApiData(FilingApi filing, String confirmationStatementId) throws SubmissionNotFoundException {
+        Optional<ConfirmationStatementSubmissionJson> submissionOpt =
+                confirmationStatementService.getConfirmationStatement(confirmationStatementId);
+        if(submissionOpt.isEmpty()){
+            throw new SubmissionNotFoundException(
+                    String.format("Empty submission returned when generating filing for %s", confirmationStatementId));
+        }
+        ConfirmationStatementSubmissionJson submission = submissionOpt.get();
+        if(submission.getData() != null) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
+            data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
+            data.put("dtr5Ind", false);
+            filing.setData(data);
+        }
+    }
+
+    private void setDescription(FilingApi filing) {
+        LocalDate madeUpToDate = (LocalDate)filing.getData().get("confirmationStatementDate");
+        String description = environment.getProperty("confirmation.statement.no.updates");
+        String madeUpDateStr = madeUpToDate.format(formatter);
+        filing.setDescription(description.replace("(made_up_date)", madeUpDateStr));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -37,17 +37,18 @@ public class FilingService {
     private void setFilingApiData(FilingApi filing, String confirmationStatementId) throws SubmissionNotFoundException {
         Optional<ConfirmationStatementSubmissionJson> submissionOpt =
                 confirmationStatementService.getConfirmationStatement(confirmationStatementId);
-        if(submissionOpt.isEmpty()){
+        if(submissionOpt.isPresent()) {
+            ConfirmationStatementSubmissionJson submission = submissionOpt.get();
+            if (submission.getData() != null) {
+                Map<String, Object> data = new HashMap<>();
+                data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
+                data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
+                data.put("dtr5Ind", false);
+                filing.setData(data);
+            }
+        } else {
             throw new SubmissionNotFoundException(
                     String.format("Empty submission returned when generating filing for %s", confirmationStatementId));
-        }
-        ConfirmationStatementSubmissionJson submission = submissionOpt.get();
-        if(submission.getData() != null) {
-            Map<String, Object> data = new HashMap<>();
-            data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
-            data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
-            data.put("dtr5Ind", false);
-            filing.setData(data);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
@@ -16,14 +16,15 @@ import java.util.Optional;
 @Service
 public class FilingService {
 
+    @Value("${CONFIRMATION_STATEMENT_NO_UPDATES}")
+    private String filingDescription;
+
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
     private ConfirmationStatementService confirmationStatementService;
-    private Environment environment;
 
     @Autowired
-    public FilingService(ConfirmationStatementService csService, Environment env) {
+    public FilingService(ConfirmationStatementService csService) {
         confirmationStatementService = csService;
-        environment = env;
     }
 
     public FilingApi generateConfirmationFiling(String confirmationStatementId) throws SubmissionNotFoundException {
@@ -37,27 +38,27 @@ public class FilingService {
     private void setFilingApiData(FilingApi filing, String confirmationStatementId) throws SubmissionNotFoundException {
         Optional<ConfirmationStatementSubmissionJson> submissionOpt =
                 confirmationStatementService.getConfirmationStatement(confirmationStatementId);
-        if(submissionOpt.isPresent()) {
-            ConfirmationStatementSubmissionJson submission = submissionOpt.get();
-            if (submission.getData() != null) {
-                Map<String, Object> data = new HashMap<>();
-                data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
-                data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
-                data.put("dtr5Ind", false);
-                filing.setData(data);
-            }
+        ConfirmationStatementSubmissionJson submission = submissionOpt
+                .orElseThrow(() ->
+                        new SubmissionNotFoundException(
+                                String.format("Empty submission returned when generating filing for %s", confirmationStatementId)));
+        if (submission.getData() != null) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("confirmationStatementDate", submission.getData().getMadeUpToDate());
+            data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
+            data.put("dtr5Ind", false);
+            filing.setData(data);
         } else {
             throw new SubmissionNotFoundException(
-                    String.format("Empty submission returned when generating filing for %s", confirmationStatementId));
+                    String.format("Submission contains no data %s", confirmationStatementId));
         }
     }
 
     private void setDescription(FilingApi filing) {
         LocalDate madeUpToDate = (LocalDate)filing.getData().get("confirmationStatementDate");
-        String description = environment.getProperty("confirmation.statement.no.updates");
         String madeUpToDateStr = madeUpToDate.format(formatter);
-        filing.setDescriptionIdentifier(description);
-        filing.setDescription(description.replace("{made up date}", madeUpToDateStr));
+        filing.setDescriptionIdentifier(filingDescription);
+        filing.setDescription(filingDescription.replace("{made up date}", madeUpToDateStr));
         Map<String, String> values = new HashMap<>();
         values.put("made up date", madeUpToDateStr);
         filing.setDescriptionValues(values);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 
@@ -17,7 +16,7 @@ import java.util.Optional;
 @Service
 public class FilingService {
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
     private ConfirmationStatementService confirmationStatementService;
     private Environment environment;
 
@@ -27,9 +26,9 @@ public class FilingService {
         environment = env;
     }
 
-    public FilingApi generateConfirmationFiling(Transaction transaction, String confirmationStatementId) throws SubmissionNotFoundException {
+    public FilingApi generateConfirmationFiling(String confirmationStatementId) throws SubmissionNotFoundException {
         FilingApi filing = new FilingApi();
-        filing.setKind("CS01");
+        filing.setKind("Confirmation Statement");
         setFilingApiData(filing, confirmationStatementId);
         setDescription(filing);
         return filing;
@@ -55,8 +54,12 @@ public class FilingService {
     private void setDescription(FilingApi filing) {
         LocalDate madeUpToDate = (LocalDate)filing.getData().get("confirmationStatementDate");
         String description = environment.getProperty("confirmation.statement.no.updates");
-        String madeUpDateStr = madeUpToDate.format(formatter);
-        filing.setDescription(description.replace("(made_up_date)", madeUpDateStr));
+        String madeUpToDateStr = madeUpToDate.format(formatter);
+        filing.setDescriptionIdentifier(description);
+        filing.setDescription(description.replace("{made up date}", madeUpToDateStr));
+        Map<String, String> values = new HashMap<>();
+        values.put("made up date", madeUpToDateStr);
+        filing.setDescriptionValues(values);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Service
 public class FilingService {
 
-    @Value("${CONFIRMATION_STATEMENT_NO_UPDATES}")
+    @Value("${CONFIRMATION_STATEMENT_DESCRIPTION_NO_UPDATES}")
     private String filingDescription;
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -61,5 +61,4 @@ public class FilingService {
         values.put("made up date", madeUpToDateStr);
         filing.setDescriptionValues(values);
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.uri=${MONGODB_URL}/transaction_confirmation_statement_submissions
+confirmation.statement.no.updates=**Confirmation statement** made on (made_up_date) with no updates

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.data.mongodb.uri=${MONGODB_URL}/transaction_confirmation_statement_submissions
-confirmation.statement.no.updates=**Confirmation statement** made on (made_up_date) with no updates
+confirmation.statement.no.updates=**Confirmation statement** made on {made up date} with no updates

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,1 @@
 spring.data.mongodb.uri=${MONGODB_URL}/transaction_confirmation_statement_submissions
-confirmation.statement.no.updates=**Confirmation statement** made on {made up date} with no updates

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
@@ -6,7 +6,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
 
@@ -27,11 +26,10 @@ class FilingControllerTest {
 
     @Test
     void getFiling() throws SubmissionNotFoundException {
-        var transaction = new Transaction();
         FilingApi filing = new FilingApi();
         filing.setDescription("12345678");
-        when(filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID)).thenReturn(filing);
-        var result = filingController.getFiling(transaction, CONFIRMATION_ID);
+        when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenReturn(filing);
+        var result = filingController.getFiling(CONFIRMATION_ID);
 
         assertNotNull(result.getBody());
         assertEquals("12345678", result.getBody().getDescription());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
@@ -5,12 +5,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,5 +35,24 @@ class FilingControllerTest {
 
         assertNotNull(result.getBody());
         assertEquals("12345678", result.getBody().getDescription());
+    }
+
+
+    @Test
+    void getFilingSubmissionNotFound() throws SubmissionNotFoundException {
+        when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenThrow(SubmissionNotFoundException.class);
+        var result = filingController.getFiling(CONFIRMATION_ID);
+
+        assertNull(result.getBody());
+        assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+    }
+
+    @Test
+    void getFilingException() throws SubmissionNotFoundException {
+        when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenThrow(RuntimeException.class);
+        var result = filingController.getFiling(CONFIRMATION_ID);
+
+        assertNull(result.getBody());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
@@ -3,22 +3,35 @@ package uk.gov.companieshouse.confirmationstatementapi.controller;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class FilingControllerTest {
 
+    private static final String CONFIRMATION_ID = "abc123";
+
     @InjectMocks
     private FilingController filingController;
+
+    @Mock
+    private FilingService filingService;
+
     @Test
-    void getFiling() {
+    void getFiling() throws SubmissionNotFoundException {
         var transaction = new Transaction();
-        transaction.setDescription("12345678");
-        var result = filingController.getFiling(transaction);
+        FilingApi filing = new FilingApi();
+        filing.setDescription("12345678");
+        when(filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID)).thenReturn(filing);
+        var result = filingController.getFiling(transaction, CONFIRMATION_ID);
 
         assertNotNull(result.getBody());
         assertEquals("12345678", result.getBody().getDescription());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDataJson;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FilingServiceTest {
+
+    private static final String CONFIRMATION_ID = "abc123";
+
+    @InjectMocks
+    private FilingService filingService;
+
+    @Mock
+    private ConfirmationStatementService csService;
+
+    @Mock
+    private Environment environment;
+
+    @Test
+    void testWhenSubmissionIsReturnedSuccessfully() throws SubmissionNotFoundException {
+        ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson =  buildSubmissionJson();
+        Optional<ConfirmationStatementSubmissionJson> opt = Optional.of(confirmationStatementSubmissionJson);
+        when(environment.getProperty("confirmation.statement.no.updates")).thenReturn("**Confirmation statement** made on (made_up_date) with no updates");
+        when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(opt);
+        var transaction = new Transaction();
+        FilingApi filing = filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID);
+        assertEquals("**Confirmation statement** made on 2021-06-01 with no updates", filing.getDescription());
+        assertEquals(confirmationStatementSubmissionJson.getData().getMadeUpToDate(), filing.getData().get("confirmationStatementDate"));
+        assertFalse((Boolean) filing.getData().get("tradingOnMarket"));
+        assertFalse((Boolean) filing.getData().get("dtr5Ind"));
+    }
+
+    @Test
+    void testWhenEmptySubmissionIsReturned() {
+        when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(Optional.empty());
+        var transaction = new Transaction();
+        assertThrows(SubmissionNotFoundException.class, () -> filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID));
+    }
+
+    ConfirmationStatementSubmissionJson buildSubmissionJson() {
+        ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson =
+                new ConfirmationStatementSubmissionJson();
+        ConfirmationStatementSubmissionDataJson confirmationStatementSubmissionDataJson
+                = new ConfirmationStatementSubmissionDataJson();
+        confirmationStatementSubmissionDataJson.setMadeUpToDate(LocalDate.of(2021, 06, 01));
+        TradingStatusDataJson tradingStatus = new TradingStatusDataJson();
+        tradingStatus.setTradingStatusAnswer(true);
+        confirmationStatementSubmissionDataJson.setTradingStatusData(tradingStatus);
+        confirmationStatementSubmissionJson.setData(confirmationStatementSubmissionDataJson);
+        return confirmationStatementSubmissionJson;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -67,5 +67,4 @@ class FilingServiceTest {
         confirmationStatementSubmissionJson.setData(confirmationStatementSubmissionDataJson);
         return confirmationStatementSubmissionJson;
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
@@ -39,7 +40,7 @@ class FilingServiceTest {
     void testWhenSubmissionIsReturnedSuccessfully() throws SubmissionNotFoundException {
         ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson =  buildSubmissionJson();
         Optional<ConfirmationStatementSubmissionJson> opt = Optional.of(confirmationStatementSubmissionJson);
-        when(environment.getProperty("confirmation.statement.no.updates")).thenReturn("**Confirmation statement** made on {made up date} with no updates");
+        ReflectionTestUtils.setField(filingService, "filingDescription", "**Confirmation statement** made on {made up date} with no updates");
         when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(opt);
               FilingApi filing = filingService.generateConfirmationFiling(CONFIRMATION_ID);
         assertEquals("**Confirmation statement** made on 2021/06/01 with no updates", filing.getDescription());
@@ -51,7 +52,6 @@ class FilingServiceTest {
     @Test
     void testWhenEmptySubmissionIsReturned() {
         when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(Optional.empty());
-        var transaction = new Transaction();
         assertThrows(SubmissionNotFoundException.class, () -> filingService.generateConfirmationFiling(CONFIRMATION_ID));
     }
 

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -5,10 +5,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.Environment;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
@@ -32,9 +30,6 @@ class FilingServiceTest {
 
     @Mock
     private ConfirmationStatementService csService;
-
-    @Mock
-    private Environment environment;
 
     @Test
     void testWhenSubmissionIsReturnedSuccessfully() throws SubmissionNotFoundException {

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,11 +39,10 @@ class FilingServiceTest {
     void testWhenSubmissionIsReturnedSuccessfully() throws SubmissionNotFoundException {
         ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson =  buildSubmissionJson();
         Optional<ConfirmationStatementSubmissionJson> opt = Optional.of(confirmationStatementSubmissionJson);
-        when(environment.getProperty("confirmation.statement.no.updates")).thenReturn("**Confirmation statement** made on (made_up_date) with no updates");
+        when(environment.getProperty("confirmation.statement.no.updates")).thenReturn("**Confirmation statement** made on {made up date} with no updates");
         when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(opt);
-        var transaction = new Transaction();
-        FilingApi filing = filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID);
-        assertEquals("**Confirmation statement** made on 2021-06-01 with no updates", filing.getDescription());
+              FilingApi filing = filingService.generateConfirmationFiling(CONFIRMATION_ID);
+        assertEquals("**Confirmation statement** made on 2021/06/01 with no updates", filing.getDescription());
         assertEquals(confirmationStatementSubmissionJson.getData().getMadeUpToDate(), filing.getData().get("confirmationStatementDate"));
         assertFalse((Boolean) filing.getData().get("tradingOnMarket"));
         assertFalse((Boolean) filing.getData().get("dtr5Ind"));
@@ -54,7 +52,7 @@ class FilingServiceTest {
     void testWhenEmptySubmissionIsReturned() {
         when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(Optional.empty());
         var transaction = new Transaction();
-        assertThrows(SubmissionNotFoundException.class, () -> filingService.generateConfirmationFiling(transaction, CONFIRMATION_ID));
+        assertThrows(SubmissionNotFoundException.class, () -> filingService.generateConfirmationFiling(CONFIRMATION_ID));
     }
 
     ConfirmationStatementSubmissionJson buildSubmissionJson() {


### PR DESCRIPTION
Using submission to add data to the filing api response. No need for transaction to be passed in.