### PR TITLE
NCS-692 Changing data returned from /filings endpoint to use snake case

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -29,7 +29,7 @@ public class FilingService {
 
     public FilingApi generateConfirmationFiling(String confirmationStatementId) throws SubmissionNotFoundException {
         FilingApi filing = new FilingApi();
-        filing.setKind("Confirmation Statement");
+        filing.setKind("confirmation-statement");
         setFilingApiData(filing, confirmationStatementId);
         return filing;
     }
@@ -44,9 +44,9 @@ public class FilingService {
         if (submission.getData() != null) {
             LocalDate madeUpToDate = submission.getData().getMadeUpToDate();
             Map<String, Object> data = new HashMap<>();
-            data.put("confirmationStatementDate", madeUpToDate );
-            data.put("tradingOnMarket", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
-            data.put("dtr5Ind", false);
+            data.put("confirmation_statement_date", madeUpToDate );
+            data.put("trading_on_market", !submission.getData().getTradingStatusData().getTradingStatusAnswer());
+            data.put("dtr5_ind", false);
             filing.setData(data);
             setDescription(filing, madeUpToDate);
         } else {

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -39,9 +39,9 @@ class FilingServiceTest {
         when(csService.getConfirmationStatement(CONFIRMATION_ID)).thenReturn(opt);
               FilingApi filing = filingService.generateConfirmationFiling(CONFIRMATION_ID);
         assertEquals("**Confirmation statement** made on 2021/06/01 with no updates", filing.getDescription());
-        assertEquals(confirmationStatementSubmissionJson.getData().getMadeUpToDate(), filing.getData().get("confirmationStatementDate"));
-        assertFalse((Boolean) filing.getData().get("tradingOnMarket"));
-        assertFalse((Boolean) filing.getData().get("dtr5Ind"));
+        assertEquals(confirmationStatementSubmissionJson.getData().getMadeUpToDate(), filing.getData().get("confirmation_statement_date"));
+        assertFalse((Boolean) filing.getData().get("trading_on_market"));
+        assertFalse((Boolean) filing.getData().get("dtr5_ind"));
     }
 
     @Test


### PR DESCRIPTION
From working on the chips-filing-consumer it was apparent that the data retrieved from the /filings endpoint in this api should be in snake case format. This PR is to change the data in the /filings endpoint to use snake case.
And updated the 'kind' to be 'confirmation-statement'  (not snake case but in keeping with other kinds)

Jira Ticket - https://companieshouse.atlassian.net/browse/NCS-692