### PR TITLE
NCS-743 Fix to add transaction interceptor to /filings endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfig.java
@@ -111,7 +111,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
      */
     private void addTransactionInterceptor(InterceptorRegistry registry) {
         registry.addInterceptor(transactionInterceptor)
-                .addPathPatterns(TRANSACTIONS);
+                .addPathPatterns(TRANSACTIONS, FILINGS);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfigTest.java
@@ -67,7 +67,7 @@ class InterceptorConfigTest {
 
         // Transactions endpoints interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(transactionInterceptor);
-        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.TRANSACTIONS);
+        inOrder.verify(interceptorRegistration).addPathPatterns(InterceptorConfig.TRANSACTIONS, InterceptorConfig.FILINGS);
 
         // Filings endpoint interceptor check
         inOrder.verify(interceptorRegistry).addInterceptor(filingInterceptor);


### PR DESCRIPTION
The filings interceptor requires the transaction to be in the request but the transaction interceptor (which does this) wasn't configured for the /filings endpoint. This change is to add the /filings path to the transaction interceptor so that it will populate the transaction in the request for the filings interceptor.