### PR TITLE
NCS-726 Make /filings endpoint return an array of filings

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -22,10 +22,10 @@ public class FilingController {
     private FilingService filingService;
 
     @GetMapping
-    public ResponseEntity<FilingApi> getFiling(@PathVariable("confirmation_statement_id") String confirmationStatementId) {
+    public ResponseEntity<FilingApi[]> getFiling(@PathVariable("confirmation_statement_id") String confirmationStatementId) {
         try {
             FilingApi filing = filingService.generateConfirmationFiling(confirmationStatementId);
-            return ResponseEntity.ok(filing);
+            return ResponseEntity.ok(new FilingApi[] { filing });
         } catch (SubmissionNotFoundException e) {
             LOGGER.error(e.getMessage(), e);
             return ResponseEntity.notFound().build();

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
@@ -34,7 +34,8 @@ class FilingControllerTest {
         var result = filingController.getFiling(CONFIRMATION_ID);
 
         assertNotNull(result.getBody());
-        assertEquals("12345678", result.getBody().getDescription());
+        assertEquals(1, result.getBody().length);
+        assertEquals("12345678", result.getBody()[0].getDescription());
     }
 
 


### PR DESCRIPTION
The filing-resource-handler expects /filings to return an array of filings, so updated the /filings endpoint to wrap our filing in an array ie. array of size 1.