### PR TITLE
NCS-756 Use structured-logging framework.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.confirmationstatementapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
@@ -10,6 +12,7 @@ import java.util.TimeZone;
 public class ConfirmationStatementApiApplication {
 
 	public static final String APP_NAME = "CONFIRMATION-STATEMENT-API";
+	public static final Logger LOGGER = LoggerFactory.getLogger(APP_NAME.toLowerCase());
 
 	public static void main(String[] args) {
 		SpringApplication.run(ConfirmationStatementApiApplication.class, args);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.client;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -16,6 +14,8 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.Confirm
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,9 +24,9 @@ import java.util.List;
 @Component
 public class OracleQueryClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OracleQueryClient.class);
-    private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL (get): {}";
-    private static final String RECEIVED_FROM_ORACLE_QUERY_API_URL_GET = "Received {} from Oracle Query API URL (get): {}";
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleQueryClient.class.getName());
+    private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL (get): %s";
+    private static final String RECEIVED_FROM_ORACLE_QUERY_API_URL_GET = "Received %s from Oracle Query API URL (get): %s";
     public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
 
     @Autowired
@@ -37,35 +37,37 @@ public class OracleQueryClient {
 
     public Long getCompanyTradedStatus(String companyNumber) {
         var getCompanyTradedStatusUrl = String.format("%s/company/%s/traded-status", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, getCompanyTradedStatusUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, getCompanyTradedStatusUrl));
 
         ResponseEntity<Long> response = restTemplate.getForEntity(getCompanyTradedStatusUrl, Long.class);
         var companyTradedStatus = response.getBody();
-        LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, companyTradedStatus, getCompanyTradedStatusUrl);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, companyTradedStatus, getCompanyTradedStatusUrl));
 
         return companyTradedStatus;
     }
 
     public Integer getShareholderCount(String companyNumber) {
+
         var shareholderCountUrl = String.format("%s/company/%s/shareholders/count", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, shareholderCountUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, shareholderCountUrl));
 
         ResponseEntity<Integer> response = restTemplate.getForEntity(shareholderCountUrl, Integer.class);
         var count = response.getBody();
-        LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, count, shareholderCountUrl);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, count, shareholderCountUrl));
 
         return count;
     }
 
     public StatementOfCapitalJson getStatementOfCapitalData(String companyNumber) throws ServiceException {
         var statementOfCapitalUrl = String.format("%s/company/%s/statement-of-capital", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, statementOfCapitalUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, statementOfCapitalUrl));
 
         ResponseEntity<StatementOfCapitalJson> response = restTemplate.getForEntity(statementOfCapitalUrl, StatementOfCapitalJson.class);
         if(response.getStatusCode() == HttpStatus.OK) {
             StatementOfCapitalJson statementOfCapitalJson = response.getBody();
             if (statementOfCapitalJson != null) {
-                LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, statementOfCapitalJson, statementOfCapitalUrl);
+                LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, statementOfCapitalJson, statementOfCapitalUrl));
+
                 return statementOfCapitalJson;
             } else {
                 throw new ServiceException("Oracle query api returned no data");
@@ -78,14 +80,14 @@ public class OracleQueryClient {
 
     public ActiveDirectorDetails getActiveDirectorDetails(String companyNumber) throws ServiceException, ActiveDirectorNotFoundException {
         var directorDetailsUrl = String.format("%s/company/%s/director/active", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, directorDetailsUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, directorDetailsUrl));
 
         ResponseEntity<ActiveDirectorDetails> response = restTemplate.getForEntity(directorDetailsUrl, ActiveDirectorDetails.class);
 
         switch (response.getStatusCode()) {
         case OK:
             var directorDetails = response.getBody();
-            LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, directorDetails, directorDetailsUrl);
+            LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, directorDetails, directorDetailsUrl));
             return directorDetails;
         case NOT_FOUND:
             throw new ActiveDirectorNotFoundException("Oracle query api returned no data. Company has either multiple or no active officers");
@@ -96,10 +98,10 @@ public class OracleQueryClient {
 
     public List<PersonOfSignificantControl> getPersonsOfSignificantControl(String companyNumber) throws ServiceException {
         var pscUrl = String.format("%s/company/%s/corporate-body-appointments/persons-of-significant-control", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, pscUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, pscUrl));
 
         ResponseEntity<PersonOfSignificantControl[]> response = restTemplate.getForEntity(pscUrl, PersonOfSignificantControl[].class);
-        LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, pscUrl);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, pscUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -111,10 +113,11 @@ public class OracleQueryClient {
 
     public List<RegisterLocationJson> getRegisterLocations(String companyNumber) throws ServiceException {
         var regLocUrl = String.format("%s/company/%s/register/location", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, regLocUrl);
+
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, regLocUrl));
 
         ResponseEntity<RegisterLocationJson[]> response = restTemplate.getForEntity(regLocUrl, RegisterLocationJson[].class);
-        LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, regLocUrl);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, regLocUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -126,10 +129,10 @@ public class OracleQueryClient {
 
     public List<ShareholderJson> getShareholders(String companyNumber) throws ServiceException {
         var shareholdersUrl = String.format("%s/company/%s/shareholders", oracleQueryApiUrl, companyNumber);
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, shareholdersUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, shareholdersUrl));
 
         ResponseEntity<ShareholderJson[]> response = restTemplate.getForEntity(shareholdersUrl, ShareholderJson[].class);
-        LOGGER.info(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, shareholdersUrl);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, shareholdersUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -143,8 +146,9 @@ public class OracleQueryClient {
        var paymentsUrl = String.format(
                "%s/company/%s/confirmation-statement/paid?payment_period_made_up_to_date=%s", oracleQueryApiUrl, companyNumber, dueDate);
 
-        LOGGER.info(CALLING_ORACLE_QUERY_API_URL_GET, paymentsUrl);
+        LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, paymentsUrl));
         ResponseEntity<ConfirmationStatementPaymentJson> response = restTemplate.getForEntity(paymentsUrl, ConfirmationStatementPaymentJson.class);
+        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, paymentsUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE + " with due date %s", response.getStatusCode(), companyNumber, dueDate));
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
@@ -14,19 +14,17 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.Confirm
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
+
 @Component
 public class OracleQueryClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OracleQueryClient.class.getName());
     private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL (get): %s";
-    private static final String RECEIVED_FROM_ORACLE_QUERY_API_URL_GET = "Received %s from Oracle Query API URL (get): %s";
     public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
 
     @Autowired
@@ -41,7 +39,6 @@ public class OracleQueryClient {
 
         ResponseEntity<Long> response = restTemplate.getForEntity(getCompanyTradedStatusUrl, Long.class);
         var companyTradedStatus = response.getBody();
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, companyTradedStatus, getCompanyTradedStatusUrl));
 
         return companyTradedStatus;
     }
@@ -52,10 +49,7 @@ public class OracleQueryClient {
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, shareholderCountUrl));
 
         ResponseEntity<Integer> response = restTemplate.getForEntity(shareholderCountUrl, Integer.class);
-        var count = response.getBody();
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, count, shareholderCountUrl));
-
-        return count;
+        return response.getBody();
     }
 
     public StatementOfCapitalJson getStatementOfCapitalData(String companyNumber) throws ServiceException {
@@ -65,13 +59,8 @@ public class OracleQueryClient {
         ResponseEntity<StatementOfCapitalJson> response = restTemplate.getForEntity(statementOfCapitalUrl, StatementOfCapitalJson.class);
         if(response.getStatusCode() == HttpStatus.OK) {
             StatementOfCapitalJson statementOfCapitalJson = response.getBody();
-            if (statementOfCapitalJson != null) {
-                LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, statementOfCapitalJson, statementOfCapitalUrl));
-
-                return statementOfCapitalJson;
-            } else {
-                throw new ServiceException("Oracle query api returned no data");
-            }
+            if (statementOfCapitalJson != null) return statementOfCapitalJson;
+            else throw new ServiceException("Oracle query api returned no data");
         } else {
             throw new ServiceException("Oracle query api returned with status " + response.getStatusCode());
         }
@@ -87,7 +76,6 @@ public class OracleQueryClient {
         switch (response.getStatusCode()) {
         case OK:
             var directorDetails = response.getBody();
-            LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, directorDetails, directorDetailsUrl));
             return directorDetails;
         case NOT_FOUND:
             throw new ActiveDirectorNotFoundException("Oracle query api returned no data. Company has either multiple or no active officers");
@@ -101,7 +89,6 @@ public class OracleQueryClient {
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, pscUrl));
 
         ResponseEntity<PersonOfSignificantControl[]> response = restTemplate.getForEntity(pscUrl, PersonOfSignificantControl[].class);
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, pscUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -117,7 +104,6 @@ public class OracleQueryClient {
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, regLocUrl));
 
         ResponseEntity<RegisterLocationJson[]> response = restTemplate.getForEntity(regLocUrl, RegisterLocationJson[].class);
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, regLocUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -132,7 +118,6 @@ public class OracleQueryClient {
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, shareholdersUrl));
 
         ResponseEntity<ShareholderJson[]> response = restTemplate.getForEntity(shareholdersUrl, ShareholderJson[].class);
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, shareholdersUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
         }
@@ -148,7 +133,6 @@ public class OracleQueryClient {
 
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, paymentsUrl));
         ResponseEntity<ConfirmationStatementPaymentJson> response = restTemplate.getForEntity(paymentsUrl, ConfirmationStatementPaymentJson.class);
-        LOGGER.info(String.format(RECEIVED_FROM_ORACLE_QUERY_API_URL_GET, response, paymentsUrl));
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE + " with due date %s", response.getStatusCode(), companyNumber, dueDate));
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementController.java
@@ -17,21 +17,18 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 @RequestMapping("/transactions/{transaction_id}/confirmation-statement")
 public class ConfirmationStatementController {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementController.class.getName());
 
     private final ConfirmationStatementService confirmationStatementService;
 
@@ -41,14 +38,16 @@ public class ConfirmationStatementController {
     }
 
     @PostMapping("/")
-    public ResponseEntity<Object> createNewSubmission(@RequestAttribute("transaction") Transaction transaction, HttpServletRequest request) {
+    public ResponseEntity<Object> createNewSubmission(
+            @RequestAttribute("transaction") Transaction transaction,
+            @PathVariable("transaction_id") String transactionId,
+            HttpServletRequest request) {
 
         String passthroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
         String requestId = request.getHeader(ERIC_REQUEST_ID);
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("transaction", transaction);
-        logMap.put("passthroughHeader", passthroughHeader);
+        logMap.put("transaction_id", transactionId);
         LOGGER.infoContext(requestId, "Calling service to create submission", logMap);
 
         try {
@@ -63,22 +62,26 @@ public class ConfirmationStatementController {
     public ResponseEntity<Object> updateSubmission(
             @RequestBody ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson,
             @PathVariable("confirmation_statement_id") String submissionId,
+            @PathVariable("transaction_id") String transactionId,
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put("confirmation_statement_id", submissionId);
-        logMap.put("confirmation_statement", confirmationStatementSubmissionJson);
+        logMap.put("transaction_id", transactionId);
         LOGGER.infoContext(requestId, "Calling service to update confirmation statement data", logMap);
 
         return confirmationStatementService.updateConfirmationStatement(submissionId, confirmationStatementSubmissionJson);
     }
 
     @GetMapping("/{confirmation_statement_id}")
-    public ResponseEntity<Object> getSubmission(@PathVariable("confirmation_statement_id") String submissionId,
+    public ResponseEntity<Object> getSubmission(
+            @PathVariable("confirmation_statement_id") String submissionId,
+            @PathVariable("transaction_id") String transactionId,
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put("confirmation_statement_id", submissionId);
+        logMap.put("transaction_id", transactionId);
         LOGGER.infoContext(requestId, "Calling service to retrieve confirmation statement data", logMap);
 
         var serviceResponse = confirmationStatementService.getConfirmationStatement(submissionId);
@@ -89,10 +92,12 @@ public class ConfirmationStatementController {
     @GetMapping("/{confirmation_statement_id}/validation-status")
     public ResponseEntity<Object> getValidationStatus(
             @PathVariable("confirmation_statement_id") String submissionId,
+            @PathVariable("transaction_id") String transactionId,
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
         logMap.put("confirmation_statement_id", submissionId);
+        logMap.put("transaction_id", transactionId);
         LOGGER.infoContext(requestId, "Calling service to get validation status", logMap);
 
         try {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementController.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -18,15 +17,21 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 @RequestMapping("/transactions/{transaction_id}/confirmation-statement")
 public class ConfirmationStatementController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementController.class.getName());
 
     private final ConfirmationStatementService confirmationStatementService;
 
@@ -38,39 +43,66 @@ public class ConfirmationStatementController {
     @PostMapping("/")
     public ResponseEntity<Object> createNewSubmission(@RequestAttribute("transaction") Transaction transaction, HttpServletRequest request) {
 
-        String passthroughHeader = request
-                .getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        String passthroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        String requestId = request.getHeader(ERIC_REQUEST_ID);
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("transaction", transaction);
+        logMap.put("passthroughHeader", passthroughHeader);
+        LOGGER.infoContext(requestId, "Calling service to create submission", logMap);
+
         try {
             return confirmationStatementService.createConfirmationStatement(transaction, passthroughHeader);
         } catch (ServiceException e) {
-            LOGGER.error("Error Creating Confirmation Statement", e);
+            LOGGER.errorContext(requestId,"Error Creating Confirmation Statement", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
     @PostMapping("/{confirmation_statement_id}")
-    public ResponseEntity<Object> updateSubmission(@RequestBody ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson,
-                                                   @PathVariable("confirmation_statement_id") String submissionId) {
+    public ResponseEntity<Object> updateSubmission(
+            @RequestBody ConfirmationStatementSubmissionJson confirmationStatementSubmissionJson,
+            @PathVariable("confirmation_statement_id") String submissionId,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("confirmation_statement_id", submissionId);
+        logMap.put("confirmation_statement", confirmationStatementSubmissionJson);
+        LOGGER.infoContext(requestId, "Calling service to update confirmation statement data", logMap);
+
         return confirmationStatementService.updateConfirmationStatement(submissionId, confirmationStatementSubmissionJson);
     }
 
     @GetMapping("/{confirmation_statement_id}")
-    public ResponseEntity<Object> getSubmission(@PathVariable("confirmation_statement_id") String submissionId) {
+    public ResponseEntity<Object> getSubmission(@PathVariable("confirmation_statement_id") String submissionId,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("confirmation_statement_id", submissionId);
+        LOGGER.infoContext(requestId, "Calling service to retrieve confirmation statement data", logMap);
+
         var serviceResponse = confirmationStatementService.getConfirmationStatement(submissionId);
         return serviceResponse.<ResponseEntity<Object>>map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{confirmation_statement_id}/validation-status")
-    public ResponseEntity<Object> getValidationStatus(@PathVariable("confirmation_statement_id") String submissionId) {
+    public ResponseEntity<Object> getValidationStatus(
+            @PathVariable("confirmation_statement_id") String submissionId,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("confirmation_statement_id", submissionId);
+        LOGGER.infoContext(requestId, "Calling service to get validation status", logMap);
+
         try {
             ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(submissionId);
             return ResponseEntity.ok().body(validationStatusResponse);
         } catch (SubmissionNotFoundException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.errorContext(requestId,e.getMessage(), e, logMap);
             return ResponseEntity.notFound().build();
         } catch (Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.errorContext(requestId,e.getMessage(), e, logMap);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
@@ -1,23 +1,28 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.response.CompanyValidationResponse;
 import uk.gov.companieshouse.confirmationstatementapi.service.CompanyProfileService;
 import uk.gov.companieshouse.confirmationstatementapi.service.EligibilityService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class EligibilityController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityController.class.getName());
 
     @Autowired
     private CompanyProfileService companyProfileService;
@@ -26,15 +31,19 @@ public class EligibilityController {
     private EligibilityService eligibilityService;
 
     @GetMapping("/confirmation-statement/company/{company-number}/eligibility")
-    public ResponseEntity<CompanyValidationResponse> getEligibility(@PathVariable("company-number") String companyNumber){
-        try {
-            var companyProfile =
-                    companyProfileService.getCompanyProfile(companyNumber);
-            var companyValidationResponse =
-                    eligibilityService.checkCompanyEligibility(companyProfile);
+    public ResponseEntity<CompanyValidationResponse> getEligibility(@PathVariable("company-number") String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
-            if (EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE
-                    == companyValidationResponse.getEligibilityStatusCode()) {
+        var logMap = new HashMap<String, Object>();
+        logMap.put("requestId", requestId);
+        logMap.put("companyNumber", companyNumber);
+        LOGGER.infoContext(requestId, "Calling service to retrieve company eligibility", logMap);
+
+        try {
+            var companyProfile = companyProfileService.getCompanyProfile(companyNumber);
+            var companyValidationResponse = eligibilityService.checkCompanyEligibility(companyProfile);
+
+            if (EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE == companyValidationResponse.getEligibilityStatusCode()) {
                 return ResponseEntity.ok().body(companyValidationResponse);
             } else {
                 return ResponseEntity.badRequest().body(companyValidationResponse);
@@ -44,7 +53,7 @@ public class EligibilityController {
             companyNotFoundResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_NOT_FOUND);
             return ResponseEntity.badRequest().body(companyNotFoundResponse);
         } catch (Exception e) {
-            LOGGER.error(String.format("Error checking eligibility of company number %s", companyNumber), e);
+            LOGGER.errorContext(requestId, "Error checking eligibility of company number.", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
@@ -12,17 +12,15 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundE
 import uk.gov.companieshouse.confirmationstatementapi.model.response.CompanyValidationResponse;
 import uk.gov.companieshouse.confirmationstatementapi.service.CompanyProfileService;
 import uk.gov.companieshouse.confirmationstatementapi.service.EligibilityService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class EligibilityController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityController.class.getName());
 
     @Autowired
     private CompanyProfileService companyProfileService;
@@ -35,8 +33,7 @@ public class EligibilityController {
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("requestId", requestId);
-        logMap.put("companyNumber", companyNumber);
+        logMap.put("company_number", companyNumber);
         LOGGER.infoContext(requestId, "Calling service to retrieve company eligibility", logMap);
 
         try {
@@ -53,7 +50,7 @@ public class EligibilityController {
             companyNotFoundResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_NOT_FOUND);
             return ResponseEntity.badRequest().body(companyNotFoundResponse);
         } catch (Exception e) {
-            LOGGER.errorContext(requestId, "Error checking eligibility of company number.", e, logMap);
+            LOGGER.errorContext(requestId, "Error checking eligibility of company.", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -10,18 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 @RequestMapping("/private/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/filings")
 public class FilingController {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilingController.class.getName());
 
     @Autowired
     private FilingService filingService;
@@ -35,7 +32,6 @@ public class FilingController {
         var logMap = new HashMap<String, Object>();
         logMap.put("transaction_id", transactionId);
         logMap.put("confirmation_statement_id", confirmationStatementId);
-        logMap.put("requestId", requestId);
         LOGGER.infoContext(requestId, "Calling service to retrieve filing", logMap);
 
         try {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingController.java
@@ -1,36 +1,51 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.filinggenerator.FilingApi;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.service.FilingService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 @RequestMapping("/private/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/filings")
 public class FilingController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilingController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilingController.class.getName());
 
     @Autowired
     private FilingService filingService;
 
     @GetMapping
-    public ResponseEntity<FilingApi[]> getFiling(@PathVariable("confirmation_statement_id") String confirmationStatementId) {
+    public ResponseEntity<FilingApi[]> getFiling(
+            @PathVariable("confirmation_statement_id") String confirmationStatementId,
+            @PathVariable("transaction_id") String transactionId,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("transaction_id", transactionId);
+        logMap.put("confirmation_statement_id", confirmationStatementId);
+        logMap.put("requestId", requestId);
+        LOGGER.infoContext(requestId, "Calling service to retrieve filing", logMap);
+
         try {
             FilingApi filing = filingService.generateConfirmationFiling(confirmationStatementId);
             return ResponseEntity.ok(new FilingApi[] { filing });
         } catch (SubmissionNotFoundException e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.errorContext(requestId, e.getMessage(), e, logMap);
             return ResponseEntity.notFound().build();
         } catch (Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.errorContext(requestId, e.getMessage(), e, logMap);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
@@ -9,11 +9,10 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
@@ -22,23 +21,21 @@ public class NextMadeUpToDateController {
     @Autowired
     private ConfirmationStatementService confirmationStatementService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NextMadeUpToDateController.class.getName());
-
     @GetMapping("/confirmation-statement/company/{companyNumber}/next-made-up-to-date")
     public ResponseEntity<NextMadeUpToDateJson> getNextMadeUpToDate(@PathVariable String companyNumber,
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
         var map = new HashMap<String, Object>();
-        map.put("companyNumber", companyNumber);
+        map.put("company_number", companyNumber);
 
         try {
             LOGGER.infoContext(requestId, "Calling service to retrieve the next made up to date.", map);
             NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(companyNumber);
             return ResponseEntity.ok().body(nextMadeUpToDateJson);
         } catch(CompanyNotFoundException cnfe) {
-            LOGGER.errorContext(requestId,String.format("Unable to find company %s", companyNumber), cnfe, map);
+            LOGGER.errorContext(requestId, "Unable to find company.", cnfe, map);
             return ResponseEntity.notFound().build();
         } catch (Exception e) {
-            LOGGER.errorContext(requestId,String.format("Error retrieving next made up to date.", companyNumber), e, map);
+            LOGGER.errorContext(requestId, "Error retrieving next made up to date.", e, map);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateController.java
@@ -1,15 +1,20 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.CompanyNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ConfirmationStatementService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class NextMadeUpToDateController {
@@ -17,19 +22,23 @@ public class NextMadeUpToDateController {
     @Autowired
     private ConfirmationStatementService confirmationStatementService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NextMadeUpToDateController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NextMadeUpToDateController.class.getName());
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/next-made-up-to-date")
-    public ResponseEntity<NextMadeUpToDateJson> getNextMadeUpToDate(@PathVariable String companyNumber) {
+    public ResponseEntity<NextMadeUpToDateJson> getNextMadeUpToDate(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+        var map = new HashMap<String, Object>();
+        map.put("companyNumber", companyNumber);
+
         try {
-            LOGGER.info("Calling service to retrieve the next made up to date.");
+            LOGGER.infoContext(requestId, "Calling service to retrieve the next made up to date.", map);
             NextMadeUpToDateJson nextMadeUpToDateJson = confirmationStatementService.getNextMadeUpToDate(companyNumber);
             return ResponseEntity.ok().body(nextMadeUpToDateJson);
         } catch(CompanyNotFoundException cnfe) {
-            LOGGER.error(String.format("Unable to find company %s", companyNumber), cnfe);
+            LOGGER.errorContext(requestId,String.format("Unable to find company %s", companyNumber), cnfe, map);
             return ResponseEntity.notFound().build();
         } catch (Exception e) {
-            LOGGER.error("Error retrieving next made up to date.", e);
+            LOGGER.errorContext(requestId,String.format("Error retrieving next made up to date.", companyNumber), e, map);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
@@ -1,17 +1,22 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class OfficerController {
@@ -19,19 +24,25 @@ public class OfficerController {
     @Autowired
     private OfficerService officerService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfficerController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OfficerController.class.getName());
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/active-director-details")
-    public ResponseEntity<ActiveDirectorDetails> getActiveDirectorDetails(@PathVariable String companyNumber) {
+    public ResponseEntity<ActiveDirectorDetails> getActiveDirectorDetails(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("requestId", requestId);
+        logMap.put("companyNumber", companyNumber);
+
         try {
-            LOGGER.info("Calling service to retrieve the active director details.");
+            LOGGER.infoContext(requestId, "Calling service to retrieve the active director details.", logMap);
             var directorDetails = officerService.getActiveDirectorDetails(companyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(directorDetails);
         } catch (ActiveDirectorNotFoundException e) {
-            LOGGER.error("Error retrieving active officer details.", e);
+            LOGGER.errorContext(requestId, "Error retrieving active officer details.", e, logMap);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (ServiceException e) {
-            LOGGER.error("Error retrieving active officer details.", e);
+            LOGGER.errorContext(requestId, "Error retrieving active officer details.", e, logMap);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
@@ -11,11 +11,10 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNo
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
@@ -24,15 +23,12 @@ public class OfficerController {
     @Autowired
     private OfficerService officerService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OfficerController.class.getName());
-
     @GetMapping("/confirmation-statement/company/{companyNumber}/active-director-details")
     public ResponseEntity<ActiveDirectorDetails> getActiveDirectorDetails(@PathVariable String companyNumber,
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("requestId", requestId);
-        logMap.put("companyNumber", companyNumber);
+        logMap.put("company_number", companyNumber);
 
         try {
             LOGGER.infoContext(requestId, "Calling service to retrieve the active director details.", logMap);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonsOfSignificantControlController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonsOfSignificantControlController.java
@@ -10,17 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.PersonOfSignificantControlJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.PscService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 class PersonsOfSignificantControlController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PersonsOfSignificantControlController.class.getName());
 
     @Autowired
     private PscService pscService;
@@ -30,8 +28,7 @@ class PersonsOfSignificantControlController {
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("requestId", requestId);
-        logMap.put("companyNumber", companyNumber);
+        logMap.put("company_number", companyNumber);
 
         String sanitizedCompanyNumber = null;
         if (companyNumber != null) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonsOfSignificantControlController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonsOfSignificantControlController.java
@@ -1,47 +1,57 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.PersonOfSignificantControlJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.PscService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 class PersonsOfSignificantControlController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PersonsOfSignificantControlController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersonsOfSignificantControlController.class.getName());
 
     @Autowired
     private PscService pscService;
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/persons-of-significant-control")
-    public ResponseEntity<List<PersonOfSignificantControlJson>> getPersonsOfSignificantControl(@PathVariable String companyNumber) {
+    public ResponseEntity<List<PersonOfSignificantControlJson>> getPersonsOfSignificantControl(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("requestId", requestId);
+        logMap.put("companyNumber", companyNumber);
+
         String sanitizedCompanyNumber = null;
         if (companyNumber != null) {
             sanitizedCompanyNumber = companyNumber.replaceAll("[\n|\r|\t]", "_");
         }
 
         try {
-            LOGGER.info("Calling PscService to retrieve persons of significant control for companyNumber {}", sanitizedCompanyNumber);
+            LOGGER.infoContext(requestId, String.format("Calling PscService to retrieve persons of significant control for companyNumber %s", sanitizedCompanyNumber), logMap);
             var pscs = pscService.getPSCsFromOracle(sanitizedCompanyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(pscs);
         } catch (ServiceException e) {
-            logErrorMessage(sanitizedCompanyNumber, e);
+            logErrorMessage(requestId, sanitizedCompanyNumber, logMap, e);
             return ResponseEntity.internalServerError().build();
         } catch (Exception e) {
-            logErrorMessage(sanitizedCompanyNumber, e);
+            logErrorMessage(requestId, sanitizedCompanyNumber, logMap, e);
             throw e;
         }
     }
 
-    private void logErrorMessage(String sanitizedCompanyNumber, Exception e) {
-        LOGGER.error("Error retrieving persons of significant control for companyNumber {}", sanitizedCompanyNumber, e);
+    private void logErrorMessage(String requestId, String sanitizedCompanyNumber, HashMap logMap, Exception e) {
+        LOGGER.errorContext(requestId, String.format("Calling PscService to retrieve persons of significant control for companyNumber %s", sanitizedCompanyNumber), e, logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsController.java
@@ -10,17 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.RegisterLocationService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class RegisterLocationsController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterLocationsController.class.getName());
 
     private RegisterLocationService regLocService;
 
@@ -34,8 +32,7 @@ public class RegisterLocationsController {
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("requestId", requestId);
-        logMap.put("companyNumber", companyNumber);
+        logMap.put("company_number", companyNumber);
 
         try {
             LOGGER.infoContext(requestId, "Calling service to retrieve register locations data.", logMap);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsController.java
@@ -1,22 +1,26 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.RegisterLocationService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class RegisterLocationsController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterLocationsController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterLocationsController.class.getName());
 
     private RegisterLocationService regLocService;
 
@@ -26,13 +30,19 @@ public class RegisterLocationsController {
     }
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/register-locations")
-    public ResponseEntity<List<RegisterLocationJson>> getRegisterLocations(@PathVariable String companyNumber) {
+    public ResponseEntity<List<RegisterLocationJson>> getRegisterLocations(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("requestId", requestId);
+        logMap.put("companyNumber", companyNumber);
+
         try {
-            LOGGER.info("Calling service to retrieve register locations data");
+            LOGGER.infoContext(requestId, "Calling service to retrieve register locations data.", logMap);
             var registerLocations = regLocService.getRegisterLocations(companyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(registerLocations);
         } catch (ServiceException e) {
-            LOGGER.error("Error retrieving register locations data ", e);
+            LOGGER.errorContext(requestId, "Error retrieving register locations data.", e, logMap);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderController.java
@@ -10,17 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ShareholderService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class ShareholderController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ShareholderController.class.getName());
 
     private ShareholderService shareholderService;
 
@@ -34,7 +32,7 @@ public class ShareholderController {
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var map = new HashMap<String, Object>();
-        map.put("companyNumber", companyNumber);
+        map.put("company_number", companyNumber);
 
         try {
             LOGGER.infoContext(requestId, "Calling service to retrieve shareholders data", map);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderController.java
@@ -1,22 +1,26 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.ShareholderService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class ShareholderController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ShareholderController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShareholderController.class.getName());
 
     private ShareholderService shareholderService;
 
@@ -26,13 +30,18 @@ public class ShareholderController {
     }
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/shareholders")
-    public ResponseEntity<List<ShareholderJson>> getShareholders(@PathVariable String companyNumber) {
+    public ResponseEntity<List<ShareholderJson>> getShareholders(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var map = new HashMap<String, Object>();
+        map.put("companyNumber", companyNumber);
+
         try {
-            LOGGER.info("Calling service to retrieve shareholders data");
+            LOGGER.infoContext(requestId, "Calling service to retrieve shareholders data", map);
             var shareholders = shareholderService.getShareholders(companyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(shareholders);
         } catch (ServiceException e) {
-            LOGGER.error("Error retrieving shareholders data ", e);
+            LOGGER.errorContext(requestId,"Error retrieving shareholders data", e, map);
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
@@ -10,17 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.StatementOfCapitalService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.HashMap;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class StatementOfCapitalController {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(StatementOfCapitalController.class.getName());
 
     private final StatementOfCapitalService statementOfCapitalService;
 
@@ -34,8 +31,7 @@ public class StatementOfCapitalController {
             @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
 
         var logMap = new HashMap<String, Object>();
-        logMap.put("requestId", requestId);
-        logMap.put("companyNumber", companyNumber);
+        logMap.put("company_number", companyNumber);
 
         try {
             LOGGER.infoContext(requestId, "Calling service to retrieve statement of capital data.", logMap);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
@@ -1,21 +1,26 @@
 package uk.gov.companieshouse.confirmationstatementapi.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.StatementOfCapitalService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.HashMap;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID;
 
 @RestController
 public class StatementOfCapitalController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StatementOfCapitalController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatementOfCapitalController.class.getName());
 
     private final StatementOfCapitalService statementOfCapitalService;
 
@@ -25,13 +30,19 @@ public class StatementOfCapitalController {
     }
 
     @GetMapping("/confirmation-statement/company/{companyNumber}/statement-of-capital")
-    public ResponseEntity<StatementOfCapitalJson> getStatementOfCapital(@PathVariable String companyNumber) {
+    public ResponseEntity<StatementOfCapitalJson> getStatementOfCapital(@PathVariable String companyNumber,
+            @RequestHeader(value = ERIC_REQUEST_ID) String requestId) {
+
+        var logMap = new HashMap<String, Object>();
+        logMap.put("requestId", requestId);
+        logMap.put("companyNumber", companyNumber);
+
         try {
-            LOGGER.info("Calling service to retrieve statement of capital data");
+            LOGGER.infoContext(requestId, "Calling service to retrieve statement of capital data.", logMap);
             var statementOfCapital = statementOfCapitalService.getStatementOfCapital(companyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(statementOfCapital);
         } catch (ServiceException e) {
-            LOGGER.error("Error retrieving statement of capital data ", e);
+            LOGGER.errorContext(requestId, "Error retrieving statement of capital data.", e, logMap);
             return ResponseEntity.notFound().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyOfficerValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyOfficerValidation.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.officers.CompanyOfficerApi;
@@ -11,12 +9,14 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.List;
 
 public class CompanyOfficerValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyOfficerValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyOfficerValidation.class.getName());
 
     private final OfficerService officerService;
 
@@ -30,7 +30,7 @@ public class CompanyOfficerValidation implements EligibilityRule<CompanyProfileA
 
     @Override
     public void validate(CompanyProfileApi companyProfileApi) throws EligibilityException, ServiceException {
-        LOGGER.info("Validating Company Officers for: {}", companyProfileApi.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company Officers for: %s", companyProfileApi.getCompanyNumber()));
         if (!officerValidationFlag) {
             LOGGER.debug("OFFICER VALIDATION FEATURE FLAG off skipping validation");
             return;
@@ -38,10 +38,10 @@ public class CompanyOfficerValidation implements EligibilityRule<CompanyProfileA
         var officers = officerService.getOfficers(companyProfileApi.getCompanyNumber());
         var officerCheck = isOfficerDirector(officers.getItems(), officers.getActiveCount());
         if (!officerCheck) {
-            LOGGER.info("Company Officers validation failed for: {}", companyProfileApi.getCompanyNumber());
+            LOGGER.info(String.format("Company Officers validation failed for: %s", companyProfileApi.getCompanyNumber()));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_APPOINTMENTS_INVALID_NUMBER_OF_OFFICERS);
         }
-        LOGGER.info("Company Officers validation passed for: {}", companyProfileApi.getCompanyNumber());
+        LOGGER.info(String.format("Company Officers validation passed for: %s", companyProfileApi.getCompanyNumber()));
     }
 
     public boolean isOfficerDirector(List<CompanyOfficerApi> officers, Long activeCount) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyOfficerValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyOfficerValidation.java
@@ -9,14 +9,12 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.List;
 
-public class CompanyOfficerValidation implements EligibilityRule<CompanyProfileApi> {
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyOfficerValidation.class.getName());
+public class CompanyOfficerValidation implements EligibilityRule<CompanyProfileApi> {
 
     private final OfficerService officerService;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyPscCountValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyPscCountValidation.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.PscService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 public class CompanyPscCountValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyPscCountValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyPscCountValidation.class.getName());
 
     private final PscService pscService;
 
@@ -24,17 +24,17 @@ public class CompanyPscCountValidation implements EligibilityRule<CompanyProfile
 
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException, ServiceException {
-        LOGGER.info("Validating Company PSCs for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company PSCs for: %s", profileToValidate.getCompanyNumber()));
         if (!companyPscCountValidationFeatureFlag) {
             LOGGER.debug("Company PSC Count FEATURE FLAG off skipping validation");
             return;
         }
         var count = pscService.getPSCsFromCHS(profileToValidate.getCompanyNumber()).getActiveCount();
         if (count != null && count > 1) {
-            LOGGER.info("Company PSCs validation failed for: {}", profileToValidate.getCompanyNumber());
+            LOGGER.info(String.format("Company PSCs validation failed for: %s", profileToValidate.getCompanyNumber()));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_APPOINTMENTS_MORE_THAN_ONE_PSC);
         }
-        LOGGER.info("Company PSCs validation passed for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Company PSCs validation passed for: %s", profileToValidate.getCompanyNumber()));
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyPscCountValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyPscCountValidation.java
@@ -6,12 +6,10 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.PscService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 public class CompanyPscCountValidation implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyPscCountValidation.class.getName());
 
     private final PscService pscService;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidation.java
@@ -1,16 +1,16 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.service.ShareholderService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 public class CompanyShareholderCountValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyShareholderCountValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyShareholderCountValidation.class.getName());
 
     private final ShareholderService shareholderService;
     private final boolean validationFlag;
@@ -27,7 +27,7 @@ public class CompanyShareholderCountValidation implements EligibilityRule<Compan
             return;
         }
 
-        LOGGER.info("Validating Company shareholder count for: {}", companyProfile.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company shareholder count for: %s", companyProfile.getCompanyNumber()));
 
         // Exclude companies limited by guarantee.
         if (!companyProfile.getType().contains("private-limited-guarant-nsc")) {
@@ -35,12 +35,12 @@ public class CompanyShareholderCountValidation implements EligibilityRule<Compan
             var count = shareholderService.getShareholderCount(coNumber);
 
             if (count > 1) {
-                LOGGER.info("Company shareholder count for {} failed with {} shareholders", coNumber, count);
+                LOGGER.info(String.format("Company shareholder count for %s failed with %s shareholders", coNumber, count));
                 throw new EligibilityException(
                         EligibilityStatusCode.INVALID_COMPANY_APPOINTMENTS_MORE_THAN_ONE_SHAREHOLDER);
             }
 
-            LOGGER.info("Company shareholder count validation successful for {} with value {}", coNumber, count);
+            LOGGER.info(String.format("Company shareholder count validation successful for %s with value %s", coNumber, count));
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyShareholderCountValidation.java
@@ -5,12 +5,10 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRul
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.service.ShareholderService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 public class CompanyShareholderCountValidation implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyShareholderCountValidation.class.getName());
 
     private final ShareholderService shareholderService;
     private final boolean validationFlag;

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyStatusValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyStatusValidation.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.Set;
 
 public class CompanyStatusValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyStatusValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyStatusValidation.class.getName());
 
     private final Set<String> allowedStatuses;
 
@@ -21,13 +21,13 @@ public class CompanyStatusValidation implements EligibilityRule<CompanyProfileAp
 
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
-        LOGGER.info("Validating Company Status for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company Status for: %s", profileToValidate.getCompanyNumber()));
         var status = profileToValidate.getCompanyStatus();
 
         if (!allowedStatuses.contains(status)) {
-            LOGGER.info("Company Status validation failed for: {}", profileToValidate.getCompanyNumber());
+            LOGGER.info(String.format("Company Status validation failed for: %s", profileToValidate.getCompanyNumber()));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_STATUS);
         }
-        LOGGER.info("Company Status validation passed for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Company Status validation passed for: %s", profileToValidate.getCompanyNumber()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyStatusValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyStatusValidation.java
@@ -4,14 +4,12 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 import java.util.Set;
 
 public class CompanyStatusValidation implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyStatusValidation.class.getName());
 
     private final Set<String> allowedStatuses;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTradedStatusValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTradedStatusValidation.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.model.CompanyTradedStatusType;
 import uk.gov.companieshouse.confirmationstatementapi.service.CorporateBodyService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 public class CompanyTradedStatusValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTradedStatusValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTradedStatusValidation.class.getName());
 
     private final CorporateBodyService corporateBodyService;
     private final boolean tradedStatusEligibilityFlag;
@@ -24,7 +24,7 @@ public class CompanyTradedStatusValidation implements EligibilityRule<CompanyPro
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
         var companyNumber = profileToValidate.getCompanyNumber();
-        LOGGER.info("Validating Company Traded Status for: {}", companyNumber);
+        LOGGER.info(String.format("Validating Company Traded Status for: %s", companyNumber));
         if (!tradedStatusEligibilityFlag) {
             LOGGER.debug("TRADED STATUS VALIDATION FEATURE FLAG off skipping validation");
             return;
@@ -33,9 +33,9 @@ public class CompanyTradedStatusValidation implements EligibilityRule<CompanyPro
         var companyTradedStatus = corporateBodyService.getCompanyTradedStatus(companyNumber);
 
         if(CompanyTradedStatusType.NOT_ADMITTED_TO_TRADING != companyTradedStatus) {
-            LOGGER.info("Company traded status validation failed for {} with value {}", companyNumber, companyTradedStatus);
+            LOGGER.info(String.format("Company traded status validation failed for %s with value %s", companyNumber, companyTradedStatus));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_TRADED_STATUS_USE_WEBFILING);
         }
-        LOGGER.info("Company traded status validation successful for {} with value {}", companyNumber, companyTradedStatus);
+        LOGGER.info(String.format("Company traded status validation successful for %s with value %s", companyNumber, companyTradedStatus));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTradedStatusValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTradedStatusValidation.java
@@ -6,12 +6,10 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.model.CompanyTradedStatusType;
 import uk.gov.companieshouse.confirmationstatementapi.service.CorporateBodyService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 public class CompanyTradedStatusValidation implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTradedStatusValidation.class.getName());
 
     private final CorporateBodyService corporateBodyService;
     private final boolean tradedStatusEligibilityFlag;

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeCS01FilingNotRequiredValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeCS01FilingNotRequiredValidation.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.Set;
 
 public class CompanyTypeCS01FilingNotRequiredValidation implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeCS01FilingNotRequiredValidation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeCS01FilingNotRequiredValidation.class.getName());
 
     private final Set<String> companyTypesNotRequiredToFile;
 
@@ -21,13 +21,13 @@ public class CompanyTypeCS01FilingNotRequiredValidation implements EligibilityRu
 
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
-        LOGGER.info("Validating Company Type is CS01 Required for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company Type is CS01 Required for: %s", profileToValidate.getCompanyNumber()));
         var type = profileToValidate.getType();
 
         if(companyTypesNotRequiredToFile.contains(type)) {
-            LOGGER.info("Company Type validation is CS01 Required failed for: {}", profileToValidate.getCompanyNumber());
+            LOGGER.info(String.format("Company Type validation is CS01 Required failed for: %s", profileToValidate.getCompanyNumber()));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_TYPE_CS01_FILING_NOT_REQUIRED);
         }
-        LOGGER.info("Company Type validation is CS01 Required passed for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Company Type validation is CS01 Required passed for: %s", profileToValidate.getCompanyNumber()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeCS01FilingNotRequiredValidation.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeCS01FilingNotRequiredValidation.java
@@ -4,14 +4,12 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 import java.util.Set;
 
-public class CompanyTypeCS01FilingNotRequiredValidation implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeCS01FilingNotRequiredValidation.class.getName());
+public class CompanyTypeCS01FilingNotRequiredValidation implements EligibilityRule<CompanyProfileApi> { ;
 
     private final Set<String> companyTypesNotRequiredToFile;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationForWebFiling.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationForWebFiling.java
@@ -1,17 +1,18 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Set;
 
 public class CompanyTypeValidationForWebFiling implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationForWebFiling.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationForWebFiling.class.getName());
 
     private final Set<String> webFilingTypes;
 
@@ -21,11 +22,13 @@ public class CompanyTypeValidationForWebFiling implements EligibilityRule<Compan
 
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
-        LOGGER.info("Validating Company Type Should Use Web Filing for: {}", profileToValidate.getCompanyNumber());
+        var logMap = new HashMap<String, Object>();
+        logMap.put("companyProfile", profileToValidate);
+        LOGGER.info(String.format("Validating Company Type Should Use Web Filing for: %s", profileToValidate.getCompanyNumber()), logMap);
         if (webFilingTypes.contains(profileToValidate.getType())) {
-            LOGGER.info("Company Type validation Should Use Web Filing failed for: {}", profileToValidate.getCompanyNumber());
+            LOGGER.info(String.format("Company Type validation Should Use Web Filing failed for: %s", profileToValidate.getCompanyNumber()), logMap);
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_TYPE_USE_WEB_FILING);
         }
-        LOGGER.info("Company Type validation Should Use Web Filing passed for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Company Type validation Should Use Web Filing passed for: %s", profileToValidate.getCompanyNumber()), logMap);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationForWebFiling.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationForWebFiling.java
@@ -4,15 +4,13 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 import java.util.HashMap;
 import java.util.Set;
 
 public class CompanyTypeValidationForWebFiling implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationForWebFiling.class.getName());
 
     private final Set<String> webFilingTypes;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationPaperOnly.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationPaperOnly.java
@@ -1,17 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.eligibility.impl;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.Set;
 
 public class CompanyTypeValidationPaperOnly implements EligibilityRule<CompanyProfileApi> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationPaperOnly.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationPaperOnly.class.getName());
 
     private final Set<String> paperOnlyCompanyTypes;
 
@@ -21,13 +21,13 @@ public class CompanyTypeValidationPaperOnly implements EligibilityRule<CompanyPr
 
     @Override
     public void validate(CompanyProfileApi profileToValidate) throws EligibilityException {
-        LOGGER.info("Validating Company Type Paper Filing Only for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Validating Company Type Paper Filing Only for: %s", profileToValidate.getCompanyNumber()));
         var companyType = profileToValidate.getType();
 
         if (paperOnlyCompanyTypes.contains(companyType)) {
-            LOGGER.info("Company Type Paper Filing Only failed for: {}", profileToValidate.getCompanyNumber());
+            LOGGER.info(String.format("Company Type Paper Filing Only failed for: %s", profileToValidate.getCompanyNumber()));
             throw new EligibilityException(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
         }
-        LOGGER.info("Company Type Paper Filing Only passed for: {}", profileToValidate.getCompanyNumber());
+        LOGGER.info(String.format("Company Type Paper Filing Only passed for: %s", profileToValidate.getCompanyNumber()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationPaperOnly.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/eligibility/impl/CompanyTypeValidationPaperOnly.java
@@ -4,14 +4,12 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityRule;
 import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilityStatusCode;
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 import java.util.Set;
 
 public class CompanyTypeValidationPaperOnly implements EligibilityRule<CompanyProfileApi> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyTypeValidationPaperOnly.class.getName());
 
     private final Set<String> paperOnlyCompanyTypes;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/FilingInterceptor.java
@@ -1,11 +1,11 @@
 package uk.gov.companieshouse.confirmationstatementapi.interceptor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class FilingInterceptor implements HandlerInterceptor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilingInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilingInterceptor.class.getName());
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -26,11 +26,11 @@ public class FilingInterceptor implements HandlerInterceptor {
         }
 
         if (TransactionStatus.CLOSED.equals(transaction.getStatus())) {
-            LOGGER.debug("{} closed proceeding to generate filing", transaction.getId());
+            LOGGER.debug(String.format("%s closed proceeding to generate filing", transaction.getId()));
             return true;
         }
 
-        LOGGER.info("{} not closed rejecting filing request", transaction.getId());
+        LOGGER.debug(String.format("%s not closed rejecting filing request", transaction.getId()));
 
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         return false;

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/FilingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/FilingInterceptor.java
@@ -4,16 +4,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
+
 @Component
 public class FilingInterceptor implements HandlerInterceptor {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilingInterceptor.class.getName());
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.confirmationstatementapi.interceptor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class LoggingInterceptor implements HandlerInterceptor{
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingInterceptor.class.getName());
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -23,9 +23,7 @@ public class LoggingInterceptor implements HandlerInterceptor{
 
         MDC.put("context", requestId(request));
         MDC.put("namespace", ConfirmationStatementApiApplication.APP_NAME);
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Start of request. Method: {} Path: {}", requestMethod(request), requestPath(request));
-        }
+        LOGGER.info(String.format("Start of request. Method: %s Path: %s", requestMethod(request), requestPath(request)));
         return true;
     }
 
@@ -34,10 +32,8 @@ public class LoggingInterceptor implements HandlerInterceptor{
         Long startTime = (Long) request.getSession().getAttribute("start-time");
         long responseTime = System.currentTimeMillis() - startTime;
 
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("End of request. Method: {} Path: {} Duration: {}ms Status: {}",
-                    requestMethod(request), requestPath(request), responseTime, response.getStatus());
-        }
+        LOGGER.info(String.format("End of request. Method: %s Path: %s Duration: %sms Status: %s",
+                requestMethod(request), requestPath(request), responseTime, response.getStatus()));
 
         MDC.clear();
     }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/LoggingInterceptor.java
@@ -5,16 +5,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
+
 @Component
 public class LoggingInterceptor implements HandlerInterceptor{
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingInterceptor.class.getName());
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/TransactionInterceptor.java
@@ -1,13 +1,13 @@
 package uk.gov.companieshouse.confirmationstatementapi.interceptor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.TransactionService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
@@ -17,7 +17,7 @@ import java.util.Map;
 @Component
 public class TransactionInterceptor implements HandlerInterceptor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionInterceptor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionInterceptor.class.getName());
 
     private final TransactionService transactionService;
 
@@ -36,7 +36,7 @@ public class TransactionInterceptor implements HandlerInterceptor {
         try {
             LOGGER.debug("Getting transaction for request");
             final var transaction = transactionService.getTransaction(transactionId, passthroughHeader);
-            LOGGER.debug("Transaction retrieved: {}", transaction);
+            LOGGER.debug(String.format("Transaction retrieved: %s", transaction));
             request.setAttribute("transaction", transaction);
             return true;
         } catch (ServiceException ex) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/TransactionInterceptor.java
@@ -6,18 +6,16 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.service.TransactionService;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
+
 @Component
 public class TransactionInterceptor implements HandlerInterceptor {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionInterceptor.class.getName());
 
     private final TransactionService transactionService;
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +23,8 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDat
 import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.net.URI;
 import java.time.LocalDate;
@@ -38,7 +38,7 @@ import java.util.function.Supplier;
 @Service
 public class ConfirmationStatementService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementService.class.getName());
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Value("${FEATURE_FLAG_ENABLE_PAYMENT_CHECK_26082021:true}")
@@ -117,7 +117,7 @@ public class ConfirmationStatementService {
 
         transactionService.updateTransaction(transaction, passthroughHeader);
 
-        LOGGER.info("Confirmation Statement created for transaction id: {} with Submission id: {}", transaction.getId(), updatedSubmission.getId());
+        LOGGER.info(String.format("Confirmation Statement created for transaction id: %s with Submission id: %s",  transaction.getId(), updatedSubmission.getId()));
         var responseObject = confirmationStatementJsonDaoMapper.daoToJson(updatedSubmission);
         return ResponseEntity.created(URI.create(createdUri)).body(responseObject);
     }
@@ -148,10 +148,10 @@ public class ConfirmationStatementService {
 
         if (submission.isPresent()) {
             // Save updated submission to database
-            LOGGER.info("{}: Confirmation Statement Submission found. About to update", submission.get().getId());
+            LOGGER.info(String.format("%s: Confirmation Statement Submission found. About to update",  submission.get().getId()));
             var dao = confirmationStatementJsonDaoMapper.jsonToDao(confirmationStatementSubmissionJson);
             var savedResponse = confirmationStatementSubmissionsRepository.save(dao);
-            LOGGER.info("{}: Confirmation Statement Submission updated", savedResponse.getId());
+            LOGGER.info(String.format("%s: Confirmation Statement Submission updated",  savedResponse.getId()));
             return ResponseEntity.ok(savedResponse);
         } else {
             return ResponseEntity.notFound().build();
@@ -207,7 +207,7 @@ public class ConfirmationStatementService {
         var submission = confirmationStatementSubmissionsRepository.findById(submissionId);
 
         if (submission.isPresent()) {
-            LOGGER.info("{}: Confirmation Statement Submission found. About to return", submission.get().getId());
+            LOGGER.info(String.format("%s: Confirmation Statement Submission found. About to return",  submission.get().getId()));
 
             var json = confirmationStatementJsonDaoMapper.daoToJson(submission.get());
             return Optional.of(json);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -23,8 +23,6 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDat
 import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.net.URI;
 import java.time.LocalDate;
@@ -35,10 +33,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
+
 @Service
 public class ConfirmationStatementService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfirmationStatementService.class.getName());
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Value("${FEATURE_FLAG_ENABLE_PAYMENT_CHECK_26082021:true}")

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EligibilityService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EligibilityService.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -11,13 +9,15 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.response.CompanyValidationResponse;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.List;
 
 @Service
 public class EligibilityService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityService.class.getName());
     private final List<EligibilityRule<CompanyProfileApi>> eligibilityRules;
 
     @Autowired
@@ -33,7 +33,7 @@ public class EligibilityService {
                 eligibilityRule.validate(companyProfile);
             }
         } catch (EligibilityException e) {
-            LOGGER.info("Company {} ineligible to use the service because {}", companyProfile.getCompanyNumber(), e.getEligibilityStatusCode());
+            LOGGER.info(String.format("Company %s ineligible to use the service because %s",  companyProfile.getCompanyNumber(), e.getEligibilityStatusCode()));
             response.setEligibilityStatusCode(e.getEligibilityStatusCode());
             return response;
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EligibilityService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EligibilityService.java
@@ -9,15 +9,14 @@ import uk.gov.companieshouse.confirmationstatementapi.eligibility.EligibilitySta
 import uk.gov.companieshouse.confirmationstatementapi.exception.EligibilityException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.model.response.CompanyValidationResponse;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.List;
+
+import static uk.gov.companieshouse.confirmationstatementapi.ConfirmationStatementApiApplication.LOGGER;
 
 @Service
 public class EligibilityService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EligibilityService.class.getName());
     private final List<EligibilityRule<CompanyProfileApi>> eligibilityRules;
 
     @Autowired

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/Constants.java
@@ -1,0 +1,6 @@
+package uk.gov.companieshouse.confirmationstatementapi.utils;
+
+public class Constants {
+
+    public static final String ERIC_REQUEST_ID = "X-Request-Id";
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementControllerTest.java
@@ -34,6 +34,7 @@ class ConfirmationStatementControllerTest {
     private static final ResponseEntity<Object> NOT_FOUND_RESPONSE = ResponseEntity.notFound().build();
     private static final String PASSTHROUGH = "13456";
     private static final String SUBMISSION_ID = "ABCDEFG";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
     private ConfirmationStatementService confirmationStatementService;
@@ -85,7 +86,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.updateConfirmationStatement(SUBMISSION_ID, confirmationStatementSubmissionJson))
                 .thenReturn(UPDATED_SUCCESS_RESPONSE);
 
-        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID);
+        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID, ERICK_REQUEST_ID);
 
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
     }
@@ -95,7 +96,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.updateConfirmationStatement(SUBMISSION_ID, confirmationStatementSubmissionJson))
                 .thenReturn(NOT_FOUND_RESPONSE);
 
-        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID);
+        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID, ERICK_REQUEST_ID);
 
         assertEquals(NOT_FOUND_RESPONSE, response);
     }
@@ -105,7 +106,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.getConfirmationStatement(SUBMISSION_ID))
                 .thenReturn(Optional.of(new ConfirmationStatementSubmissionJson()));
 
-        var response = confirmationStatementController.getSubmission(SUBMISSION_ID);
+        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
@@ -115,7 +116,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.getConfirmationStatement(SUBMISSION_ID))
                 .thenReturn(Optional.empty());
 
-        var response = confirmationStatementController.getSubmission(SUBMISSION_ID);
+        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, ERICK_REQUEST_ID);
 
         assertEquals(NOT_FOUND_RESPONSE, response);
     }
@@ -125,7 +126,7 @@ class ConfirmationStatementControllerTest {
         ValidationStatusResponse validationStatus = new ValidationStatusResponse();
         validationStatus.setValid(true);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenReturn(validationStatus);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
         assertEquals(ResponseEntity.ok().body(validationStatus), response);
     }
 
@@ -139,7 +140,7 @@ class ConfirmationStatementControllerTest {
         errors[0] = error;
         validationStatus.setValidationStatusError(errors);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenReturn(validationStatus);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
         assertEquals(ResponseEntity.ok().body(validationStatus), response);
     }
 
@@ -148,7 +149,7 @@ class ConfirmationStatementControllerTest {
         ValidationStatusResponse validationStatus = new ValidationStatusResponse();
         validationStatus.setValid(true);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenThrow(SubmissionNotFoundException.class);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
         assertThrows(SubmissionNotFoundException.class, () -> confirmationStatementService.isValid(SUBMISSION_ID));
         assertEquals(NOT_FOUND_RESPONSE, response);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ConfirmationStatementControllerTest.java
@@ -34,6 +34,7 @@ class ConfirmationStatementControllerTest {
     private static final ResponseEntity<Object> NOT_FOUND_RESPONSE = ResponseEntity.notFound().build();
     private static final String PASSTHROUGH = "13456";
     private static final String SUBMISSION_ID = "ABCDEFG";
+    private static final String TRANSACTION_ID = "GFEDCBA";
     private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
@@ -59,7 +60,7 @@ class ConfirmationStatementControllerTest {
     @Test
     void createNewSubmission() throws ServiceException {
         when(confirmationStatementService.createConfirmationStatement(transaction, PASSTHROUGH)).thenReturn(CREATED_SUCCESS_RESPONSE);
-        var response = confirmationStatementController.createNewSubmission(transaction, mockHttpServletRequest);
+        var response = confirmationStatementController.createNewSubmission(transaction,TRANSACTION_ID, mockHttpServletRequest);
 
         assertEquals(CREATED_SUCCESS_RESPONSE, response);
     }
@@ -67,7 +68,7 @@ class ConfirmationStatementControllerTest {
     @Test
     void createNewSubmissionValidationFailedResponse() throws ServiceException {
         when(confirmationStatementService.createConfirmationStatement(transaction, PASSTHROUGH)).thenReturn(VALIDATION_FAILED_RESPONSE);
-        var response = confirmationStatementController.createNewSubmission(transaction, mockHttpServletRequest);
+        var response = confirmationStatementController.createNewSubmission(transaction,TRANSACTION_ID, mockHttpServletRequest);
 
         assertEquals(VALIDATION_FAILED_RESPONSE, response);
     }
@@ -76,7 +77,7 @@ class ConfirmationStatementControllerTest {
     void createNewSubmissionServiceException() throws ServiceException {
         when(confirmationStatementService.createConfirmationStatement(transaction, PASSTHROUGH)).thenThrow(new ServiceException("ERROR", new IOException()));
 
-        var response = confirmationStatementController.createNewSubmission(transaction, mockHttpServletRequest);
+        var response = confirmationStatementController.createNewSubmission(transaction,TRANSACTION_ID, mockHttpServletRequest);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
@@ -86,7 +87,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.updateConfirmationStatement(SUBMISSION_ID, confirmationStatementSubmissionJson))
                 .thenReturn(UPDATED_SUCCESS_RESPONSE);
 
-        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID,TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertEquals(UPDATED_SUCCESS_RESPONSE, response);
     }
@@ -96,7 +97,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.updateConfirmationStatement(SUBMISSION_ID, confirmationStatementSubmissionJson))
                 .thenReturn(NOT_FOUND_RESPONSE);
 
-        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.updateSubmission(confirmationStatementSubmissionJson, SUBMISSION_ID,TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertEquals(NOT_FOUND_RESPONSE, response);
     }
@@ -106,7 +107,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.getConfirmationStatement(SUBMISSION_ID))
                 .thenReturn(Optional.of(new ConfirmationStatementSubmissionJson()));
 
-        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
@@ -116,7 +117,7 @@ class ConfirmationStatementControllerTest {
         when(confirmationStatementService.getConfirmationStatement(SUBMISSION_ID))
                 .thenReturn(Optional.empty());
 
-        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.getSubmission(SUBMISSION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertEquals(NOT_FOUND_RESPONSE, response);
     }
@@ -126,7 +127,7 @@ class ConfirmationStatementControllerTest {
         ValidationStatusResponse validationStatus = new ValidationStatusResponse();
         validationStatus.setValid(true);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenReturn(validationStatus);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
         assertEquals(ResponseEntity.ok().body(validationStatus), response);
     }
 
@@ -140,7 +141,7 @@ class ConfirmationStatementControllerTest {
         errors[0] = error;
         validationStatus.setValidationStatusError(errors);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenReturn(validationStatus);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
         assertEquals(ResponseEntity.ok().body(validationStatus), response);
     }
 
@@ -149,7 +150,7 @@ class ConfirmationStatementControllerTest {
         ValidationStatusResponse validationStatus = new ValidationStatusResponse();
         validationStatus.setValid(true);
         when(confirmationStatementService.isValid(SUBMISSION_ID)).thenThrow(SubmissionNotFoundException.class);
-        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID, ERICK_REQUEST_ID);
+        var response = confirmationStatementController.getValidationStatus(SUBMISSION_ID,TRANSACTION_ID, ERICK_REQUEST_ID);
         assertThrows(SubmissionNotFoundException.class, () -> confirmationStatementService.isValid(SUBMISSION_ID));
         assertEquals(NOT_FOUND_RESPONSE, response);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 class EligibilityControllerTest {
 
     private static final String COMPANY_NUMBER = "11111111";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
     private CompanyProfileService companyProfileService;
@@ -40,7 +41,7 @@ class EligibilityControllerTest {
         CompanyValidationResponse companyValidationResponse = new CompanyValidationResponse();
         companyValidationResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE);
         when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(companyValidationResponse);
-        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(200, response.getStatusCodeValue());
     }
 
@@ -52,28 +53,28 @@ class EligibilityControllerTest {
         CompanyValidationResponse companyValidationResponse = new CompanyValidationResponse();
         companyValidationResponse.setEligibilityStatusCode(EligibilityStatusCode.INVALID_COMPANY_STATUS);
         when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(companyValidationResponse);
-        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(400, response.getStatusCodeValue());
     }
 
     @Test
     void testServiceExceptionGetEligibility() throws ServiceException, CompanyNotFoundException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new ServiceException("", new Exception()));
-        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(500, response.getStatusCodeValue());
     }
 
     @Test
     void testUncheckedExceptionGetEligibility() throws ServiceException, CompanyNotFoundException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new RuntimeException("runtime exception"));
-        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(500, response.getStatusCodeValue());
     }
 
     @Test
     void testCompanyNotFound() throws ServiceException, CompanyNotFoundException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new CompanyNotFoundException());
-        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER);
+        ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(400, response.getStatusCodeValue());
         assertNotNull(response.getBody());
         assertEquals(EligibilityStatusCode.COMPANY_NOT_FOUND, response.getBody().getEligibilityStatusCode());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/FilingControllerTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.when;
 class FilingControllerTest {
 
     private static final String CONFIRMATION_ID = "abc123";
+    private static final String TRANSACTION_ID = "def456";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @InjectMocks
     private FilingController filingController;
@@ -31,7 +33,7 @@ class FilingControllerTest {
         FilingApi filing = new FilingApi();
         filing.setDescription("12345678");
         when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenReturn(filing);
-        var result = filingController.getFiling(CONFIRMATION_ID);
+        var result = filingController.getFiling(CONFIRMATION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertNotNull(result.getBody());
         assertEquals(1, result.getBody().length);
@@ -42,7 +44,7 @@ class FilingControllerTest {
     @Test
     void getFilingSubmissionNotFound() throws SubmissionNotFoundException {
         when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenThrow(SubmissionNotFoundException.class);
-        var result = filingController.getFiling(CONFIRMATION_ID);
+        var result = filingController.getFiling(CONFIRMATION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertNull(result.getBody());
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
@@ -51,7 +53,7 @@ class FilingControllerTest {
     @Test
     void getFilingException() throws SubmissionNotFoundException {
         when(filingService.generateConfirmationFiling(CONFIRMATION_ID)).thenThrow(RuntimeException.class);
-        var result = filingController.getFiling(CONFIRMATION_ID);
+        var result = filingController.getFiling(CONFIRMATION_ID, TRANSACTION_ID, ERICK_REQUEST_ID);
 
         assertNull(result.getBody());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/NextMadeUpToDateControllerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 class NextMadeUpToDateControllerTest {
 
     private static final String COMPANY_NUMBER = "12345678";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
     private static final NextMadeUpToDateJson NEXT_MADE_UP_TO_DATE_JSON = new NextMadeUpToDateJson();
 
     @Mock
@@ -44,7 +45,7 @@ class NextMadeUpToDateControllerTest {
         when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
                 .thenReturn(NEXT_MADE_UP_TO_DATE_JSON);
 
-        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(NEXT_MADE_UP_TO_DATE_JSON, response.getBody());
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -55,7 +56,7 @@ class NextMadeUpToDateControllerTest {
         when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
                 .thenThrow(new CompanyNotFoundException());
 
-        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
@@ -66,7 +67,7 @@ class NextMadeUpToDateControllerTest {
         when(confirmationStatementService.getNextMadeUpToDate(COMPANY_NUMBER))
                 .thenThrow(new NullPointerException());
 
-        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER);
+        ResponseEntity<NextMadeUpToDateJson> response = nextMadeUpToDateController.getNextMadeUpToDate(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertNull(response.getBody());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerControllerTest.java
@@ -24,25 +24,26 @@ class OfficerControllerTest {
     private OfficerController officerController;
 
     private static final String COMPANY_NUMBER = "12345678";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Test
     void testGetActiveDirectorDetails() throws ActiveDirectorNotFoundException, ServiceException {
         when(officerService.getActiveDirectorDetails(COMPANY_NUMBER)).thenReturn(new ActiveDirectorDetails());
-        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER);
+        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
     void testGetActiveDirectorDetailsServiceException() throws ActiveDirectorNotFoundException, ServiceException {
         when(officerService.getActiveDirectorDetails(COMPANY_NUMBER)).thenThrow(ServiceException.class);
-        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER);
+        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
     void testGetActiveDirectorDetailsOfficerNotFoundException() throws ActiveDirectorNotFoundException, ServiceException {
         when(officerService.getActiveDirectorDetails(COMPANY_NUMBER)).thenThrow(ActiveDirectorNotFoundException.class);
-        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER);
+        var response = officerController.getActiveDirectorDetails(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonOfSignificantControlJsonControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/PersonOfSignificantControlJsonControllerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 class PersonOfSignificantControlJsonControllerTest {
 
     private static final String COMPANY_NUMBER = "12777531";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
     private PscService pscService;
@@ -32,7 +33,7 @@ class PersonOfSignificantControlJsonControllerTest {
     void testGetPersonsOfSignificantControlOKResponse() throws ServiceException {
         var pscs = Arrays.asList(new PersonOfSignificantControlJson(), new PersonOfSignificantControlJson());
         when(pscService.getPSCsFromOracle(COMPANY_NUMBER)).thenReturn(pscs);
-        var response = personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER);
+        var response = personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(pscs, response.getBody());
@@ -41,7 +42,7 @@ class PersonOfSignificantControlJsonControllerTest {
     @Test
     void testGetPersonsOfSignificantControlServiceException() throws ServiceException {
         when(pscService.getPSCsFromOracle(COMPANY_NUMBER)).thenThrow(new ServiceException("Message"));
-        var response = personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER);
+        var response = personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
@@ -50,7 +51,7 @@ class PersonOfSignificantControlJsonControllerTest {
     void testGetPersonsOfSignificantControlUncheckedException() throws ServiceException {
         var runtimeException = new RuntimeException("Message");
         when(pscService.getPSCsFromOracle(COMPANY_NUMBER)).thenThrow(runtimeException);
-        var thrown = assertThrows(Exception.class, () -> personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER));
+        var thrown = assertThrows(Exception.class, () -> personsOfSignificantControlController.getPersonsOfSignificantControl(COMPANY_NUMBER, ERICK_REQUEST_ID));
 
         assertEquals(runtimeException, thrown);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/RegisterLocationsControllerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 class RegisterLocationsControllerTest {
 
     private static final String COMPANY_NUMBER = "12345678";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
     private RegisterLocationService regLocService;
@@ -31,7 +32,7 @@ class RegisterLocationsControllerTest {
     void testGetRegisterLocationsOKResponse() throws ServiceException {
         var registerLocations = Arrays.asList(new RegisterLocationJson(), new RegisterLocationJson());
         when(regLocService.getRegisterLocations(COMPANY_NUMBER)).thenReturn(registerLocations);
-        var response = regLocController.getRegisterLocations(COMPANY_NUMBER);
+        var response = regLocController.getRegisterLocations(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(registerLocations, response.getBody());
@@ -40,7 +41,7 @@ class RegisterLocationsControllerTest {
     @Test
     void testGetRegisterLocationsServiceException() throws ServiceException {
         when(regLocService.getRegisterLocations(COMPANY_NUMBER)).thenThrow(new ServiceException("Internal Server Error"));
-        var response = regLocController.getRegisterLocations(COMPANY_NUMBER);
+        var response = regLocController.getRegisterLocations(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
@@ -49,7 +50,7 @@ class RegisterLocationsControllerTest {
     void testGetRegisterLocationsUncheckedException() throws ServiceException {
         var runtimeException = new RuntimeException("Runtime Error");
         when(regLocService.getRegisterLocations(COMPANY_NUMBER)).thenThrow(runtimeException);
-        var thrown = assertThrows(Exception.class, () -> regLocController.getRegisterLocations(COMPANY_NUMBER));
+        var thrown = assertThrows(Exception.class, () -> regLocController.getRegisterLocations(COMPANY_NUMBER, ERICK_REQUEST_ID));
 
         assertEquals(runtimeException, thrown);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderJsonControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/ShareholderJsonControllerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 class ShareholderJsonControllerTest {
 
     private static final String COMPANY_NUMBER = "12345678";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Mock
     private ShareholderService shareholderService;
@@ -31,7 +32,7 @@ class ShareholderJsonControllerTest {
     void testGetShareholderOKResponse() throws ServiceException {
         var shareholder = Arrays.asList(new ShareholderJson(), new ShareholderJson());
         when(shareholderService.getShareholders(COMPANY_NUMBER)).thenReturn(shareholder);
-        var response = shareholderController.getShareholders(COMPANY_NUMBER);
+        var response = shareholderController.getShareholders(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(shareholder, response.getBody());
@@ -40,7 +41,7 @@ class ShareholderJsonControllerTest {
     @Test
     void testGetShareholderServiceException() throws ServiceException {
         when(shareholderService.getShareholders(COMPANY_NUMBER)).thenThrow(new ServiceException("Internal Server Error"));
-        var response = shareholderController.getShareholders(COMPANY_NUMBER);
+        var response = shareholderController.getShareholders(COMPANY_NUMBER, ERICK_REQUEST_ID);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
@@ -49,7 +50,7 @@ class ShareholderJsonControllerTest {
     void testGetShareholderUncheckedException() throws ServiceException {
         var runtimeException = new RuntimeException("Runtime Error");
         when(shareholderService.getShareholders(COMPANY_NUMBER)).thenThrow(runtimeException);
-        var thrown = assertThrows(Exception.class, () -> shareholderController.getShareholders(COMPANY_NUMBER));
+        var thrown = assertThrows(Exception.class, () -> shareholderController.getShareholders(COMPANY_NUMBER, ERICK_REQUEST_ID));
 
         assertEquals(runtimeException, thrown);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalJsonControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalJsonControllerTest.java
@@ -23,18 +23,19 @@ class StatementOfCapitalJsonControllerTest {
     private StatementOfCapitalController statementOfCapitalController;
 
     private static final String COMPANY_NUMBER = "11111111";
+    private static final String ERICK_REQUEST_ID = "XaBcDeF12345";
 
     @Test
     void getStatementOfCapital() throws ServiceException {
         when(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER)).thenReturn(new StatementOfCapitalJson());
-        var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER);
+        var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
     void getStatementOfCapitalServiceException() throws ServiceException {
         when(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER)).thenThrow(ServiceException.class);
-        var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER);
+        var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER, ERICK_REQUEST_ID);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 


### PR DESCRIPTION
- Changed logging `org.slf4j.Logger` --> `uk.gov.companieshouse.logging.Logger`.
- Change logging namespace to **_confirmation-statement-api_** to enable filtering the logs in Kibana.
- Formatted log key names to snake case.
- Removed request/response data from logs to avoid logging sensitive/secure data and data protection law breaches.