### PR TITLE
Ncs 762 further inconsistencies

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -434,6 +434,83 @@
         }
       }
     },
+    "ConfirmationStatementSubmissionData": {
+      "type": "object",
+      "properties": {
+        "statement_of_capital_data": {
+          "type": "object",
+          "properties": {
+            "statement_of_capital": {
+              "$ref": "#/definitions/StatementOfCapitalResponse"
+            },
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "persons_significant_control_data": {
+          "type": "object",
+          "properties": {
+            "persons_significant_control": {
+              "$ref": "#/definitions/PersonsOfSignificantControl"
+            },
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "sic_code_data": {
+          "type": "object",
+          "properties": {
+            "sic_code": {
+              "$ref": "#/definitions/SicCodeResponse"
+            },
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "registered_office_address_data": {
+          "type": "object",
+          "properties": {
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "active_director_details_data": {
+          "type": "object",
+          "properties": {
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "shareholder_data": {
+          "type": "object",
+          "properties": {
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "register_locations_data": {
+          "type": "object",
+          "properties": {
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
+        "confirmation_statement_made_up_to_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "trading_status_data": {
+          "$ref": "#/definitions/TradingStatusResponse"
+        }
+      }
+    },
     "CompanyValidationResponse": {
       "type": "object",
       "properties": {
@@ -807,16 +884,61 @@
         }
       }
     },
-    "ConfirmationStatementSubmissionData": {
+    "TradingStatusResponse": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
+        "trading_status_answer": {
+          "type": "boolean"
         }
       }
+    },
+    "PersonsOfSignificantControl": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "nationality": {
+            "type": "string"
+          },
+          "full_date_of_birth": {
+            "type": "string",
+            "format": "date"
+          },
+          "usual_residential_address": {
+            "type": "string"
+          },
+          "correspondence_address": {
+            "type": "string"
+          },
+          "natures_of_control": {
+            "type": "string"
+          }
+        }
+    },
+    "SicCodeResponse": {
+      "type": "object",
+      "properties": {
+        "SicCodeData": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "SectionStatusResponse": {
+      "type": "string",
+      "enum": [
+        "CONFIRMED",
+        "NOT_CONFIRMED",
+        "RECENT_FILING"
+      ]
     }
   }
 }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "title": "Companies House - Confirmation Statement API"
   },
-  "host": "internalapi.companieshouse.gov.uk",
+  "host": "api.companieshouse.gov.uk",
   "schemes": [
     "https"
   ],
@@ -416,10 +416,7 @@
     "ConfirmationStatementCreated": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string",
-          "format": "uuid"
-        }
+        "$ref": "#/definitions/ConfirmationStatementSubmission"
       }
     },
     "ConfirmationStatementSubmission": {
@@ -428,6 +425,9 @@
         "id": {
           "type": "string",
           "format": "uuid"
+        },
+        "data": {
+          "$ref": "#/definitions/ConfirmationStatementSubmissionData"
         },
         "links": {
           "type": "object",
@@ -497,9 +497,6 @@
           "type": "integer"
         },
         "prescribedParticulars":  {
-          "type": "string"
-        },
-        "totalCurrency":  {
           "type": "string"
         },
         "totalNumberOfShares":  {
@@ -806,6 +803,17 @@
       }
     },
     "Description": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "ConfirmationStatementSubmissionData": {
       "type": "object",
       "properties": {
         "key": {

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -404,9 +404,6 @@
           },
           "404": {
             "description": "Submission not found"
-          },
-          "500": {
-            "description": "Internal server error"
           }
         }
       }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -36,7 +36,7 @@
           "201": {
             "description": "A Confirmation Statement Submission has been created.",
             "schema": {
-              "$ref": "#/definitions/ConfirmationStatementCreated"
+              "$ref": "#/definitions/ConfirmationStatementSubmission"
             }
           },
           "400": {
@@ -413,12 +413,6 @@
     }
   },
   "definitions": {
-    "ConfirmationStatementCreated": {
-      "type": "object",
-      "properties": {
-        "$ref": "#/definitions/ConfirmationStatementSubmission"
-      }
-    },
     "ConfirmationStatementSubmission": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
POST /transactions/{transaction_id}/confirmation-statement/{confirmation_statement_submission_id}
--------------------------------------
Introduced data field to the response - added response models for trading status, persons of significant control and sic codes as well as section status.

.../statement-of-capital
-----------------------
removed "totalCurrency" field from model.