### PR TITLE
bug fix updating transaction with two confirmation submitted resources

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -86,6 +86,14 @@ public class ConfirmationStatementService {
             return ResponseEntity.badRequest().body(companyValidationResponse);
         }
 
+        var allEntries = confirmationStatementSubmissionsRepository.findAll();
+
+        for (var entry : allEntries) {
+            if (entry.getLinks().toString().contains(transaction.getId())) {
+                return ResponseEntity.badRequest().body("EXISTING CONFIRMATION STATEMENT SUBMISSION FOUND FOR TRANSACTION ID: " + transaction.getId());
+            }
+        }
+
         var newSubmission = new ConfirmationStatementSubmissionDao();
         var insertedSubmission = confirmationStatementSubmissionsRepository.insert(newSubmission);
 

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -31,7 +31,10 @@ import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationSta
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
add check to create new CS submission endpoint that checks for existing submission with same transaction id