### PR TITLE
Handling SOC missing data in confirmation-statement-api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.PersonOfSignificantControl;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.ConfirmationStatementPaymentJson;
@@ -52,7 +53,7 @@ public class OracleQueryClient {
         return response.getBody();
     }
 
-    public StatementOfCapitalJson getStatementOfCapitalData(String companyNumber) throws ServiceException {
+    public StatementOfCapitalJson getStatementOfCapitalData(String companyNumber) throws ServiceException, StatementOfCapitalNotFoundException {
         var statementOfCapitalUrl = String.format("%s/company/%s/statement-of-capital", oracleQueryApiUrl, companyNumber);
         LOGGER.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, statementOfCapitalUrl));
 
@@ -63,7 +64,7 @@ public class OracleQueryClient {
                 return statementOfCapitalJson;
             }
             else {
-                throw new ServiceException("Oracle query api returned no data");
+                throw new StatementOfCapitalNotFoundException("Oracle query api returned no data");
             }
         } else {
             throw new ServiceException("Oracle query api returned with status " + response.getStatusCode());

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.StatementOfCapitalService;
 
@@ -38,9 +39,12 @@ public class StatementOfCapitalController {
             LOGGER.infoContext(requestId, "Calling service to retrieve statement of capital data.", logMap);
             var statementOfCapital = statementOfCapitalService.getStatementOfCapital(companyNumber);
             return ResponseEntity.status(HttpStatus.OK).body(statementOfCapital);
-        } catch (ServiceException e) {
-            LOGGER.infoContext(requestId, "Error retrieving statement of capital data.", logMap);
+        } catch (StatementOfCapitalNotFoundException e) {
+            LOGGER.infoContext(requestId, e.getMessage(), logMap);
             return ResponseEntity.notFound().build();
+        } catch (ServiceException e) {
+            LOGGER.errorContext(requestId, "Error retrieving statement of capital data.", e, logMap);
+            return ResponseEntity.internalServerError().build();
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/StatementOfCapitalNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/StatementOfCapitalNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.confirmationstatementapi.exception;
+
+public class StatementOfCapitalNotFoundException extends Exception {
+    public StatementOfCapitalNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/StatementOfCapitalService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/StatementOfCapitalService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 
 @Service
@@ -12,7 +13,7 @@ public class StatementOfCapitalService {
     @Autowired
     private OracleQueryClient oracleQueryClient;
 
-    public StatementOfCapitalJson getStatementOfCapital(String companyNumber) throws ServiceException {
+    public StatementOfCapitalJson getStatementOfCapital(String companyNumber) throws ServiceException, StatementOfCapitalNotFoundException {
         return oracleQueryClient.getStatementOfCapitalData(companyNumber);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.PersonOfSignificantControl;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.ConfirmationStatementPaymentJson;
@@ -73,7 +74,7 @@ class OracleQueryClientTest {
     }
 
     @Test
-    void testGetStatementOfCapitalData() throws ServiceException {
+    void testGetStatementOfCapitalData() throws ServiceException, StatementOfCapitalNotFoundException {
         when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + SOC_PATH, StatementOfCapitalJson.class))
                 .thenReturn(new ResponseEntity<>(new StatementOfCapitalJson(), HttpStatus.OK));
         StatementOfCapitalJson result = oracleQueryClient.getStatementOfCapitalData(COMPANY_NUMBER);
@@ -84,7 +85,7 @@ class OracleQueryClientTest {
     void testGetStatementOfCapitalDataNullResponse() {
         when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + SOC_PATH, StatementOfCapitalJson.class))
                 .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
-        assertThrows(ServiceException.class, () -> oracleQueryClient.getStatementOfCapitalData(COMPANY_NUMBER));
+        assertThrows(StatementOfCapitalNotFoundException.class, () -> oracleQueryClient.getStatementOfCapitalData(COMPANY_NUMBER));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalJsonControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/StatementOfCapitalJsonControllerTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.service.StatementOfCapitalService;
 
@@ -26,15 +27,22 @@ class StatementOfCapitalJsonControllerTest {
     private static final String ERIC_REQUEST_ID = "XaBcDeF12345";
 
     @Test
-    void getStatementOfCapital() throws ServiceException {
+    void getStatementOfCapital() throws ServiceException, StatementOfCapitalNotFoundException {
         when(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER)).thenReturn(new StatementOfCapitalJson());
         var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
-    void getStatementOfCapitalServiceException() throws ServiceException {
+    void getStatementOfCapitalServiceException() throws ServiceException, StatementOfCapitalNotFoundException {
         when(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER)).thenThrow(ServiceException.class);
+        var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER, ERIC_REQUEST_ID);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    void getStatementOfCapitalStatementOfCapitalNotFoundException() throws ServiceException, StatementOfCapitalNotFoundException {
+        when(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER)).thenThrow(StatementOfCapitalNotFoundException.class);
         var response = statementOfCapitalController.getStatementOfCapital(COMPANY_NUMBER, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/StatementOfCapitalJsonServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/StatementOfCapitalJsonServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -25,13 +26,13 @@ class StatementOfCapitalJsonServiceTest {
     private StatementOfCapitalService statementOfCapitalService;
 
     @Test
-    void testGetStatementOfCapitalData() throws ServiceException {
+    void testGetStatementOfCapitalData() throws ServiceException, StatementOfCapitalNotFoundException {
         when(oracleQueryClient.getStatementOfCapitalData(COMPANY_NUMBER)).thenReturn(new StatementOfCapitalJson());
         assertNotNull(statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER));
     }
 
     @Test
-    void testGetStatementOfCapitalDataServiceException() throws ServiceException {
+    void testGetStatementOfCapitalDataServiceException() throws ServiceException, StatementOfCapitalNotFoundException {
         when(oracleQueryClient.getStatementOfCapitalData(COMPANY_NUMBER)).thenThrow(ServiceException.class);
         assertThrows(ServiceException.class, () -> statementOfCapitalService.getStatementOfCapital(COMPANY_NUMBER));
     }


### PR DESCRIPTION
 Since all companies are expected to have an SOC, return a _NOT_FOUND_ and log as info since it is a data (not API) error.