### PR TITLE
Rename ActiveOfficerDetails -> ActiveOfficerDetails

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -291,13 +291,13 @@
           "200": {
             "description": "Active officer details",
             "schema": {
-              "$ref": "#/definitions/ActiveDirectorDetailsResponse"
+              "$ref": "#/definitions/ActiveOfficersDetailsResponse"
             }
           },
           "404": {
             "description": "Active officer details not found",
             "schema": {
-              "$ref": "#/definitions/ActiveDirectorDetailsResponse"
+              "$ref": "#/definitions/ActiveOfficersDetailsResponse"
             }
           }
         }
@@ -693,7 +693,7 @@
         }
       }
     },
-    "ActiveDirectorDetailsResponse": {
+    "ActiveOfficersDetailsResponse": {
       "type": "object",
       "properties": {
         "fore_name_1":  {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerController.java
@@ -9,10 +9,10 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
-import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
+import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
 import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
@@ -33,7 +33,7 @@ public class OfficerController {
     private ConfirmationStatementSubmissionsRepository confirmationStatementSubmissionsRepository;
 
     @GetMapping("/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/active-director-details")
-    public ResponseEntity<ActiveDirectorDetails> getActiveDirectorDetails(
+    public ResponseEntity<ActiveOfficerDetails> getActiveOfficersDetails(
             @RequestAttribute("transaction") Transaction transaction,
             @PathVariable(TRANSACTION_ID_KEY) String transactionId,
             @PathVariable(CONFIRMATION_STATEMENT_ID_KEY) String submissionId,
@@ -45,12 +45,12 @@ public class OfficerController {
 
         try {
             ApiLogger.infoContext(requestId, "Calling service to retrieve the active director details.", logMap);
-            var directorDetails = officerService.getActiveDirectorDetails(submissionId, transaction.getCompanyNumber());
+            var directorDetails = officerService.getActiveOfficerDetails(submissionId, transaction.getCompanyNumber());
             return ResponseEntity.status(HttpStatus.OK).body(directorDetails);
         } catch (SubmissionNotFoundException e) {
             ApiLogger.errorContext(requestId, e.getMessage(), e, logMap);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } catch (ActiveDirectorNotFoundException e) {
+        } catch (ActiveOfficerNotFoundException e) {
             ApiLogger.infoContext(requestId, "Error retrieving active officer details.", logMap);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (ServiceException e) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/ActiveDirectorNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/ActiveDirectorNotFoundException.java
@@ -1,7 +1,0 @@
-package uk.gov.companieshouse.confirmationstatementapi.exception;
-
-public class ActiveDirectorNotFoundException extends Exception {
-    public ActiveDirectorNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/ActiveOfficerNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/exception/ActiveOfficerNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.confirmationstatementapi.exception;
+
+public class ActiveOfficerNotFoundException extends Exception {
+    public ActiveOfficerNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/ActiveOfficerDetails.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/ActiveOfficerDetails.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.confirmationstatementapi.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.api.model.common.Address;
 
-public class ActiveDirectorDetails {
+public class ActiveOfficerDetails {
     @JsonProperty("fore_name_1")
     private String foreName1;
     @JsonProperty("fore_name_2")

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.dao;
 
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveDirectorDetailsDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
@@ -26,7 +26,7 @@ public class ConfirmationStatementSubmissionDataDao {
     private RegisteredOfficeAddressDataDao registeredOfficeAddressData;
 
     @Field("active_director_details_data")
-    private ActiveDirectorDetailsDataDao activeDirectorDetailsData;
+    private ActiveOfficerDetailsDataDao activeOfficerDetailsData;
 
     @Field("shareholder_data")
     private ShareholderDataDao shareholderData;
@@ -72,12 +72,12 @@ public class ConfirmationStatementSubmissionDataDao {
         this.registeredOfficeAddressData = registeredOfficeAddressDataDao;
     }
 
-    public ActiveDirectorDetailsDataDao getActiveDirectorDetailsData() {
-        return activeDirectorDetailsData;
+    public ActiveOfficerDetailsDataDao getActiveOfficerDetailsData() {
+        return activeOfficerDetailsData;
     }
 
-    public void setActiveDirectorDetailsData(ActiveDirectorDetailsDataDao activeDirectorDetailsDataDao) {
-        this.activeDirectorDetailsData = activeDirectorDetailsDataDao;
+    public void setActiveOfficerDetailsData(ActiveOfficerDetailsDataDao activeOfficerDetailsDataDao) {
+        this.activeOfficerDetailsData = activeOfficerDetailsDataDao;
     }
 
     public ShareholderDataDao getShareholdersData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/activedirectordetails/ActiveOfficerDetailsDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/activedirectordetails/ActiveOfficerDetailsDataDao.java
@@ -2,6 +2,6 @@ package uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectord
 
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.SectionDataDao;
 
-public class ActiveDirectorDetailsDataDao extends SectionDataDao {
+public class ActiveOfficerDetailsDataDao extends SectionDataDao {
 
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.confirmationstatementapi.model.json;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveDirectorDetailsDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
@@ -27,7 +27,7 @@ public class ConfirmationStatementSubmissionDataJson {
     private RegisteredOfficeAddressDataJson registeredOfficeAddressData;
 
     @JsonProperty("active_director_details_data")
-    private ActiveDirectorDetailsDataJson activeDirectorDetailsData;
+    private ActiveOfficerDetailsDataJson activeOfficerDetailsData;
 
     @JsonProperty("shareholder_data")
     private ShareholderDataJson shareholderData;
@@ -74,12 +74,12 @@ public class ConfirmationStatementSubmissionDataJson {
         this.registeredOfficeAddressData = registeredOfficeAddressDataJson;
     }
 
-    public ActiveDirectorDetailsDataJson getActiveDirectorDetailsData() {
-        return activeDirectorDetailsData;
+    public ActiveOfficerDetailsDataJson getActiveOfficerDetailsData() {
+        return activeOfficerDetailsData;
     }
 
-    public void setActiveDirectorDetailsData(ActiveDirectorDetailsDataJson activeDirectorDetailsData) {
-        this.activeDirectorDetailsData = activeDirectorDetailsData;
+    public void setActiveOfficerDetailsData(ActiveOfficerDetailsDataJson activeOfficerDetailsData) {
+        this.activeOfficerDetailsData = activeOfficerDetailsData;
     }
 
     public ShareholderDataJson getShareholdersData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/activedirectordetails/ActiveOfficerDetailsDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/activedirectordetails/ActiveOfficerDetailsDataJson.java
@@ -2,6 +2,6 @@ package uk.gov.companieshouse.confirmationstatementapi.model.json.activedirector
 
 import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
 
-public class ActiveDirectorDetailsDataJson extends SectionDataJson {
+public class ActiveOfficerDetailsDataJson extends SectionDataJson {
 
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -176,7 +176,7 @@ public class ConfirmationStatementService {
 
                 boolean isValid = isConfirmed(submissionData.getShareholdersData()) &&
                         isConfirmed(submissionData.getSicCodeData()) &&
-                        isConfirmed(submissionData.getActiveDirectorDetailsData()) &&
+                        isConfirmed(submissionData.getActiveOfficerDetailsData()) &&
                         isConfirmed(submissionData.getStatementOfCapitalData()) &&
                         isConfirmed(submissionData.getRegisteredOfficeAddressData()) &&
                         isConfirmed(submissionData.getPersonsSignificantControlData()) &&

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -8,10 +9,10 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.confirmationstatementapi.client.ApiClientService;
 import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
-import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
-import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
+import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
 import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
 
@@ -43,7 +44,8 @@ public class OfficerService {
         }
     }
 
-    public ActiveDirectorDetails getActiveDirectorDetails(String submissionId, String companyNumber) throws ServiceException, ActiveDirectorNotFoundException, SubmissionNotFoundException {
+    public ActiveOfficerDetails getActiveOfficerDetails(String submissionId, String companyNumber) throws ServiceException,
+            ActiveOfficerNotFoundException, SubmissionNotFoundException {
         var submission = confirmationStatementSubmissionsRepository.findById(submissionId);
         if (submission.isPresent()) {
             ApiLogger.info(String.format("Found submission data for submission %s", submissionId));

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
@@ -11,10 +11,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.api.model.common.Address;
-import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
-import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
+import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.PersonOfSignificantControl;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.ConfirmationStatementPaymentJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
@@ -96,10 +96,10 @@ class OracleQueryClientTest {
     }
 
     @Test
-    void testGetActiveDirectorDetailsOkStatusResponse() throws ServiceException, ActiveDirectorNotFoundException {
+    void testGetActiveDirectorDetailsOkStatusResponse() throws ServiceException, ActiveOfficerNotFoundException {
 
-        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveDirectorDetails.class))
-                .thenReturn(new ResponseEntity<>(new ActiveDirectorDetails(), HttpStatus.OK));
+        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveOfficerDetails.class))
+                .thenReturn(new ResponseEntity<>(new ActiveOfficerDetails(), HttpStatus.OK));
 
         var result = oracleQueryClient.getActiveDirectorDetails(COMPANY_NUMBER);
         assertNotNull(result);
@@ -107,15 +107,15 @@ class OracleQueryClientTest {
 
     @Test
     void testGetActiveDirectorDetailsStatus400Response() {
-        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveDirectorDetails.class))
+        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveOfficerDetails.class))
                 .thenReturn(new ResponseEntity<>(HttpStatus.NOT_FOUND));
 
-        assertThrows(ActiveDirectorNotFoundException.class, () -> oracleQueryClient.getActiveDirectorDetails(COMPANY_NUMBER));
+        assertThrows(ActiveOfficerNotFoundException.class, () -> oracleQueryClient.getActiveDirectorDetails(COMPANY_NUMBER));
     }
 
     @Test
     void testGetActiveDirectorDetailsNotOkStatusResponse() {
-        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveDirectorDetails.class))
+        when(restTemplate.getForEntity(DUMMY_URL + "/company/" + COMPANY_NUMBER + ACTIVE_DIRECTOR_PATH, ActiveOfficerDetails.class))
                 .thenReturn(new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE));
 
         assertThrows(ServiceException.class, () -> oracleQueryClient.getActiveDirectorDetails(COMPANY_NUMBER));

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/OfficerControllerTest.java
@@ -7,14 +7,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
-import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
+import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
 import uk.gov.companieshouse.confirmationstatementapi.service.OfficerService;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -39,30 +37,30 @@ class OfficerControllerTest {
     private static final String SUBMISSION_ID = "ABCDEFG";
 
     @Test
-    void testGetActiveDirectorDetails() throws ActiveDirectorNotFoundException, ServiceException, SubmissionNotFoundException {
-        when(officerService.getActiveDirectorDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenReturn(new ActiveDirectorDetails());
-        var response = officerController.getActiveDirectorDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
+    void testGetActiveOfficerDetails() throws ActiveOfficerNotFoundException, ServiceException, SubmissionNotFoundException {
+        when(officerService.getActiveOfficerDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenReturn(new ActiveOfficerDetails());
+        var response = officerController.getActiveOfficersDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
-    void testGetActiveDirectorDetailsServiceException() throws ActiveDirectorNotFoundException, ServiceException, SubmissionNotFoundException {
-        when(officerService.getActiveDirectorDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(ServiceException.class);
-        var response = officerController.getActiveDirectorDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
+    void testGetActiveOfficerDetailsServiceException() throws ActiveOfficerNotFoundException, ServiceException, SubmissionNotFoundException {
+        when(officerService.getActiveOfficerDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(ServiceException.class);
+        var response = officerController.getActiveOfficersDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
     }
 
     @Test
-    void testGetActiveDirectorDetailsOfficerNotFoundException() throws ActiveDirectorNotFoundException, ServiceException, SubmissionNotFoundException {
-        when(officerService.getActiveDirectorDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(ActiveDirectorNotFoundException.class);
-        var response = officerController.getActiveDirectorDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
+    void testGetActiveOfficerDetailsOfficerNotFoundException() throws ActiveOfficerNotFoundException, ServiceException, SubmissionNotFoundException {
+        when(officerService.getActiveOfficerDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(ActiveOfficerNotFoundException.class);
+        var response = officerController.getActiveOfficersDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test
-    void testGetActiveDirectorDetailsSubmissionNotFoundException() throws ActiveDirectorNotFoundException, ServiceException, SubmissionNotFoundException {
-        when(officerService.getActiveDirectorDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(SubmissionNotFoundException.class);
-        var response = officerController.getActiveDirectorDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
+    void testGetActiveOfficerDetailsSubmissionNotFoundException() throws ActiveOfficerNotFoundException, ServiceException, SubmissionNotFoundException {
+        when(officerService.getActiveOfficerDetails(SUBMISSION_ID, transaction.getCompanyNumber())).thenThrow(SubmissionNotFoundException.class);
+        var response = officerController.getActiveOfficersDetails(transaction, TRANSACTION_ID, SUBMISSION_ID, ERIC_REQUEST_ID);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
-import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveDirectorDetailsDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
@@ -15,7 +15,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapit
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapital.StatementOfCapitalDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDataJson;
-import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveDirectorDetailsDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
@@ -84,8 +84,8 @@ class JsonDaoMappingTest {
         SicCodeDao sicDao = sicDataDao.getSicCode();
         RegisteredOfficeAddressDataJson roaJson = json.getData().getRegisteredOfficeAddressData();
         RegisteredOfficeAddressDataDao roaDao = dao.getData().getRegisteredOfficeAddressData();
-        ActiveDirectorDetailsDataJson dirJson = json.getData().getActiveDirectorDetailsData();
-        ActiveDirectorDetailsDataDao dirDao = dao.getData().getActiveDirectorDetailsData();
+        ActiveOfficerDetailsDataJson dirJson = json.getData().getActiveOfficerDetailsData();
+        ActiveOfficerDetailsDataDao dirDao = dao.getData().getActiveOfficerDetailsData();
         ShareholderDataJson shareholderJson = json.getData().getShareholdersData();
         ShareholderDataDao shareholderDao = dao.getData().getShareholdersData();
         RegisterLocationsDataJson rlJson = json.getData().getRegisterLocationsData();

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.confirmationstatementapi.model;
 
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
-import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveDirectorDetailsDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonSignificantControlDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapit
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapital.StatementOfCapitalDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDataJson;
-import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveDirectorDetailsDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonSignificantControlJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
@@ -36,7 +36,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlJsonData());
         data.setSicCodeData(getSicCodeJsonData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressJsonData());
-        data.setActiveDirectorDetailsData(getActiveDirectorDetailsJsonData());
+        data.setActiveOfficerDetailsData(getActiveOfficerDetailsJsonData());
         data.setShareholdersData(getShareholdersJsonData());
         data.setRegisterLocationsData(getRegisterLocationsData());
         data.setTradingStatusData(getTradingStatusJsonData());
@@ -97,8 +97,8 @@ public class MockConfirmationStatementSubmissionData {
         return registeredOfficeAddressData;
     }
 
-    private static ActiveDirectorDetailsDataJson getActiveDirectorDetailsJsonData() {
-        var activeDirectorDetailsData = new ActiveDirectorDetailsDataJson();
+    private static ActiveOfficerDetailsDataJson getActiveOfficerDetailsJsonData() {
+        var activeDirectorDetailsData = new ActiveOfficerDetailsDataJson();
         activeDirectorDetailsData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
 
         return activeDirectorDetailsData;
@@ -131,7 +131,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlDaoData());
         data.setSicCodeData(getSicCodeDaoData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressDaoData());
-        data.setActiveDirectorDetailsData(getActiveDirectorDetailsDaoData());
+        data.setActiveOfficerDetailsData(getActiveOfficerDetailsDaoData());
         data.setShareholdersData(getShareholdersDaoData());
         data.setRegisterLocationsData(getRegisterLocationsDaoData());
         data.setMadeUpToDate(LocalDate.of(2021, 5, 12));
@@ -191,11 +191,11 @@ public class MockConfirmationStatementSubmissionData {
         return registeredOfficeAddressData;
     }
 
-    private static ActiveDirectorDetailsDataDao getActiveDirectorDetailsDaoData() {
-        var activeDirectorDetailsData = new ActiveDirectorDetailsDataDao();
-        activeDirectorDetailsData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
+    private static ActiveOfficerDetailsDataDao getActiveOfficerDetailsDaoData() {
+        var activeOfficerDetailsData = new ActiveOfficerDetailsDataDao();
+        activeOfficerDetailsData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
 
-        return activeDirectorDetailsData;
+        return activeOfficerDetailsData;
     }
 
     private static ShareholderDataDao getShareholdersDaoData() {

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -331,7 +331,7 @@ class ConfirmationStatementServiceTest {
     @Test
     void areTasksCompleteWithSomeNotPresent() throws SubmissionNotFoundException {
         makeAllMockTasksConfirmed();
-        confirmationStatementSubmissionJson.getData().setActiveDirectorDetailsData(null);
+        confirmationStatementSubmissionJson.getData().setActiveOfficerDetailsData(null);
         var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
         confirmationStatementSubmission.setId(SUBMISSION_ID);
         when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
@@ -501,7 +501,7 @@ class ConfirmationStatementServiceTest {
 
     void makeAllMockTasksConfirmed() {
         ConfirmationStatementSubmissionDataJson data = confirmationStatementSubmissionJson.getData();
-        data.getActiveDirectorDetailsData().setSectionStatus(SectionStatus.CONFIRMED);
+        data.getActiveOfficerDetailsData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getStatementOfCapitalData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getSicCodeData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getShareholdersData() .setSectionStatus(SectionStatus.CONFIRMED);

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/OfficerServiceTest.java
@@ -16,10 +16,10 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.officers.OfficersApi;
 import uk.gov.companieshouse.confirmationstatementapi.client.ApiClientService;
 import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
-import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveDirectorNotFoundException;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.SubmissionNotFoundException;
-import uk.gov.companieshouse.confirmationstatementapi.model.ActiveDirectorDetails;
+import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDao;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
 
@@ -120,15 +120,15 @@ class OfficerServiceTest {
     }
 
     @Test
-    void getActiveDirectorDetailsTest() throws ServiceException, ActiveDirectorNotFoundException, SubmissionNotFoundException {
+    void getActiveDirectorDetailsTest() throws ServiceException, ActiveOfficerNotFoundException, SubmissionNotFoundException {
         var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
-        ActiveDirectorDetails details = new ActiveDirectorDetails();
+        ActiveOfficerDetails details = new ActiveOfficerDetails();
         details.setForeName1("John");
         details.setSurname("Doe");
         when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
         when(oracleQueryClient.getActiveDirectorDetails(COMPANY_NUMBER)).thenReturn(details);
 
-        var response = officerService.getActiveDirectorDetails(SUBMISSION_ID, COMPANY_NUMBER);
+        var response = officerService.getActiveOfficerDetails(SUBMISSION_ID, COMPANY_NUMBER);
 
         assertEquals(response, details);
     }
@@ -138,7 +138,7 @@ class OfficerServiceTest {
         when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.empty());
 
         assertThrows(SubmissionNotFoundException.class, () -> {
-            officerService.getActiveDirectorDetails(SUBMISSION_ID, COMPANY_NUMBER);
+            officerService.getActiveOfficerDetails(SUBMISSION_ID, COMPANY_NUMBER);
         });
     }
 }


### PR DESCRIPTION
Rename all ActiveDirectorDetails classes and functions -> ActiveOfficerDetails in correlation to similar changes made to the _oracle-query-api_ and _api-sdk-node_ services. This is part of the changes to support the multiple-officer journey implementation.