### PR TITLE
NCS-828 Add officerType to ActiveOfficerDetails object

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -720,25 +720,13 @@
         "country_of_residence":  {
           "type": "string"
         },
-        "service_address_line_1":  {
-          "type": "string"
+        "service_address":  {
+          "$ref": "#/definitions/Address"
         },
-        "service_address_post_town":  {
-          "type": "string"
+        "residential_address":  {
+          "$ref": "#/definitions/Address"
         },
-        "service_address_post_code":  {
-          "type": "string"
-        },
-        "ura_line_1":  {
-          "type": "string"
-        },
-        "ura_post_town":  {
-          "type": "string"
-        },
-        "ura_post_code":  {
-          "type": "string"
-        },
-        "secure_indicator":  {
+        "officer_type":  {
           "type": "string"
         }
       }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/ActiveOfficerDetails.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/ActiveOfficerDetails.java
@@ -21,6 +21,8 @@ public class ActiveOfficerDetails {
     private Address serviceAddress;
     @JsonProperty("residential_address")
     private Address residentialAddress;
+    @JsonProperty("officer_type")
+    private String officerType;
 
     public String getForeName1() {
         return foreName1;
@@ -100,5 +102,13 @@ public class ActiveOfficerDetails {
 
     public void setDateOfAppointment(String dateOfAppointment) {
         this.dateOfAppointment = dateOfAppointment;
+    }
+
+    public String getOfficerType() {
+        return officerType;
+    }
+
+    public void setOfficerType(String officerType) {
+        this.officerType = officerType;
     }
 }


### PR DESCRIPTION
NCS-828 Add an officerType field to the ActiveOfficerDetails object to enable grouping/filtering based on their appointment type and corporate indicator.