### PR TITLE
BI-9994 Country of residence only in PSC json

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/PersonOfSignificantControlJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/PersonOfSignificantControlJson.java
@@ -27,9 +27,6 @@ public class PersonOfSignificantControlJson extends PscApi {
     @JsonProperty("legal_form")
     private String legalForm;
 
-    @JsonProperty("psc_country")
-    private String pscCountry;
-
     @JsonProperty("date_of_birth_iso")
     private String dateOfBirthIso;
 
@@ -90,14 +87,6 @@ public class PersonOfSignificantControlJson extends PscApi {
 
     public void setLegalForm(String legalForm) {
         this.legalForm = legalForm;
-    }
-
-    public String getPscCountry() {
-        return pscCountry;
-    }
-
-    public void setPscCountry(String pscCountry) {
-        this.pscCountry = pscCountry;
     }
 
     public String getDateOfBirthIso() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/personsignificantcontrol/PersonSignificantControlJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/personsignificantcontrol/PersonSignificantControlJson.java
@@ -21,8 +21,6 @@ public class PersonSignificantControlJson {
     private String correspondenceAddress;
     @JsonProperty("natures_of_control")
     private Set<String> naturesOfControl;
-    @JsonProperty("psc_country")
-    private String pscCountry;
 
     public String getName() {
         return name;
@@ -78,13 +76,5 @@ public class PersonSignificantControlJson {
 
     public void setNaturesOfControl(Set<String> naturesOfControl) {
         this.naturesOfControl = naturesOfControl;
-    }
-
-    public String getPscCountry() {
-        return pscCountry;
-    }
-
-    public void setPscCountry(String pscCountry) {
-        this.pscCountry = pscCountry;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/PscsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/PscsMapper.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 @Component
 public class PscsMapper {
 
+    private static final String PSC_APPOINTMENT_TYPE_ID = "5007";
+
     public List<PersonOfSignificantControlJson> mapToPscsApi(List<PersonOfSignificantControl> pscList) {
         if (pscList == null) {
             return new ArrayList<>();
@@ -43,13 +45,17 @@ public class PscsMapper {
         mapNames(psc, pscJson);
 
         pscJson.setNationality(psc.getOfficerNationality());
-        pscJson.setCountryOfResidence(psc.getUsualResidentialCountry());
         pscJson.setCompanyName(psc.getSuppliedCompanyName());
         pscJson.setRegisterLocation(psc.getRegisterLocation());
         pscJson.setRegistrationNumber(psc.getRegistrationNumber());
         pscJson.setLawGoverned(psc.getLawGoverned());
         pscJson.setLegalForm(psc.getLegalForm());
-        pscJson.setPscCountry(psc.getPscCountry());
+
+        if(psc.getAppointmentTypeId().equals(PSC_APPOINTMENT_TYPE_ID)) {
+            pscJson.setCountryOfResidence(psc.getUsualResidentialCountry());
+        } else {
+            pscJson.setCountryOfResidence(psc.getPscCountry());
+        }
 
         return pscJson;
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/PscsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/PscsMapperTest.java
@@ -21,35 +21,23 @@ class PscsMapperTest {
     private static final String OFFICER_DATE_OF_BIRTH_ISO = "1968-03-28";
     private static final String OFFICER_NATIONALITY = "BRITISH";
     private static final String USUAL_RESIDENTIAL_COUNTRY = "UNITED KINGDOM";
-    private static final String APPOINTMENT_TYPE_ID = "10";
+    private static final String PSC_APPOINTMENT_TYPE_ID = "5007";
+    private static final String RLE_APPOINTMENT_TYPE_ID = "5008";
     private static final String APPOINTMENT_DATE = "2020-10-10 00:00:00";
     private static final String APPOINTMENT_DATE_ISO = "2020-10-10";
     private static final String SERVICE_ADDRESS_LINE_1 = "serv line 1";
     private static final String SERVICE_ADDRESS_POST_TOWN = "cardiff";
     private static final String SERVICE_ADDRESS_POST_CODE = "CF1 1AA";
-    private static final String SERVICE_ADDRESS_COUNTRY_NAME = "country name";
-    private static final String SERVICE_ADDRESS_PO_BOX = "po box";
-    private static final String SERVICE_ADDRESS_CARE_OF = "care of";
-    private static final String SERVICE_ADDRESS_REGION = "region";
-    private static final String SERVICE_ADDRESS_AREA = "area";
-    private static final String SERVICE_ADDRESS_HOUSE_NAME_NUMBER = "house name number";
     private static final String SECURE_PSC_IND = "N";
-    private static final String HOUSE_NAME_NUMBER = "22";
-    private static final String STREET = "street";
-    private static final String AREA = "area";
     private static final String POST_TOWN = "bridgend";
     private static final String POST_CODE = "B1 1AA";
-    private static final String REGION = "region";
-    private static final String COUNTRY_NAME = "Wales";
-    private static final String PO_BOX = "po box";
-    private static final String CARE_OF = "care of";
     private static final String SUPPLIED_COMPANY_NAME = "company name";
     private static final String ADDRESS_LINE_1 = "address line 1";
     private static final String REGISTER_LOCATION = "ENGLAND";
     private static final String REGISTRATION_NUMBER = "123456";
     private static final String LAW_GOVERNED = "ENGLISH";
     private static final String LEGAL_FORM = "LIMITED";
-    private static final String PSC_COUNTRY = "UNITED KINGDOM";
+    private static final String PSC_COUNTRY = "UNITED KINGDOM RLE";
     private PscsMapper pscsMapper = new PscsMapper();
 
     @Test
@@ -82,42 +70,9 @@ class PscsMapperTest {
         assertEquals(3, pscsJson.size());
 
         var pscJson1 = pscsJson.get(0);
-        assertEquals(OFFICER_FORENAME_1 + " " + OFFICER_FORENAME_2 + " " + OFFICER_SURNAME, pscJson1.getName());
-        assertEquals(OFFICER_FORENAME_1, pscJson1.getNameElements().getForename());
-        assertEquals(OFFICER_FORENAME_2, pscJson1.getNameElements().getOtherForenames());
-        assertEquals(OFFICER_SURNAME, pscJson1.getNameElements().getSurname());
-
-        assertEquals(3L, pscJson1.getDateOfBirth().getMonth());
-        assertEquals(1968L, pscJson1.getDateOfBirth().getYear());
-        assertEquals(OFFICER_DATE_OF_BIRTH_ISO, pscJson1.getDateOfBirthIso());
+        checkPscFields(pscJson1);
+        assertEquals(PSC_APPOINTMENT_TYPE_ID, pscJson1.getAppointmentType());
         assertEquals(USUAL_RESIDENTIAL_COUNTRY, pscJson1.getCountryOfResidence());
-        assertEquals(OFFICER_NATIONALITY, pscJson1.getNationality());
-
-        assertEquals(APPOINTMENT_TYPE_ID, pscJson1.getAppointmentType());
-        assertEquals(APPOINTMENT_DATE_ISO, pscJson1.getAppointmentDate());
-
-        assertEquals(SERVICE_ADDRESS_LINE_1, pscJson1.getServiceAddress().getAddressLine1());
-        assertEquals(SERVICE_ADDRESS_POST_TOWN, pscJson1.getServiceAddress().getLocality());
-        assertEquals(SERVICE_ADDRESS_POST_CODE, pscJson1.getServiceAddress().getPostalCode());
-
-        assertEquals(ADDRESS_LINE_1, pscJson1.getAddress().getAddressLine1());
-        assertEquals(POST_TOWN, pscJson1.getAddress().getLocality());
-        assertEquals(POST_CODE, pscJson1.getAddress().getPostalCode());
-
-        assertEquals(SUPPLIED_COMPANY_NAME, pscJson1.getCompanyName());
-
-        assertEquals(REGISTER_LOCATION, pscJson1.getRegisterLocation());
-        assertEquals(REGISTRATION_NUMBER, pscJson1.getRegistrationNumber());
-        assertEquals(LAW_GOVERNED, pscJson1.getLawGoverned());
-        assertEquals(LEGAL_FORM, pscJson1.getLegalForm());
-        assertEquals(PSC_COUNTRY, pscJson1.getPscCountry());
-       
-
-        assertEquals(3, pscJson1.getNaturesOfControl().length);
-        assertEquals("12", pscJson1.getNaturesOfControl()[0]);
-        assertEquals("55", pscJson1.getNaturesOfControl()[1]);
-        assertEquals("23", pscJson1.getNaturesOfControl()[2]);
-
 
         var pscJson2 = pscsJson.get(1);
         assertEquals("James Smith", pscJson2.getName());
@@ -131,7 +86,6 @@ class PscsMapperTest {
         assertEquals("HH", pscJson2.getNaturesOfControl()[1]);
         assertEquals("XC", pscJson2.getNaturesOfControl()[2]);
 
-
         var pscJson3 = pscsJson.get(2);
         assertEquals("Kevin Lloyd", pscJson3.getName());
         assertEquals("Kevin", pscJson3.getNameElements().getForename());
@@ -144,7 +98,23 @@ class PscsMapperTest {
         assertEquals("22", pscJson3.getNaturesOfControl()[1]);
         assertEquals("88", pscJson3.getNaturesOfControl()[2]);
         assertEquals("66", pscJson3.getNaturesOfControl()[3]);
+    }
 
+    @Test
+    void testMapToRleJson() {
+        PersonOfSignificantControl rle = getPersonOfSignificantControl();
+        rle.setNatureOfControl("12;55;23");
+        rle.setAppointmentTypeId(RLE_APPOINTMENT_TYPE_ID);
+
+        List<PersonOfSignificantControl> rles = Arrays.asList(rle);
+
+        List<PersonOfSignificantControlJson> rlesJson = pscsMapper.mapToPscsApi(rles);
+        assertEquals(1, rlesJson.size());
+
+        var rleJson = rlesJson.get(0);
+        checkPscFields(rleJson);
+        assertEquals(RLE_APPOINTMENT_TYPE_ID, rleJson.getAppointmentType());
+        assertEquals(PSC_COUNTRY, rleJson.getCountryOfResidence());
     }
 
     @Test
@@ -157,6 +127,40 @@ class PscsMapperTest {
     void testEmptyInput() {
         var pscsJsons = pscsMapper.mapToPscsApi(new ArrayList<>());
         assertEquals(0, pscsJsons.size());
+    }
+
+    private void checkPscFields(PersonOfSignificantControlJson pscJson){
+        assertEquals(OFFICER_FORENAME_1 + " " + OFFICER_FORENAME_2 + " " + OFFICER_SURNAME, pscJson.getName());
+        assertEquals(OFFICER_FORENAME_1, pscJson.getNameElements().getForename());
+        assertEquals(OFFICER_FORENAME_2, pscJson.getNameElements().getOtherForenames());
+        assertEquals(OFFICER_SURNAME, pscJson.getNameElements().getSurname());
+
+        assertEquals(3L, pscJson.getDateOfBirth().getMonth());
+        assertEquals(1968L, pscJson.getDateOfBirth().getYear());
+        assertEquals(OFFICER_DATE_OF_BIRTH_ISO, pscJson.getDateOfBirthIso());
+        assertEquals(OFFICER_NATIONALITY, pscJson.getNationality());
+
+        assertEquals(APPOINTMENT_DATE_ISO, pscJson.getAppointmentDate());
+
+        assertEquals(SERVICE_ADDRESS_LINE_1, pscJson.getServiceAddress().getAddressLine1());
+        assertEquals(SERVICE_ADDRESS_POST_TOWN, pscJson.getServiceAddress().getLocality());
+        assertEquals(SERVICE_ADDRESS_POST_CODE, pscJson.getServiceAddress().getPostalCode());
+
+        assertEquals(ADDRESS_LINE_1, pscJson.getAddress().getAddressLine1());
+        assertEquals(POST_TOWN, pscJson.getAddress().getLocality());
+        assertEquals(POST_CODE, pscJson.getAddress().getPostalCode());
+
+        assertEquals(SUPPLIED_COMPANY_NAME, pscJson.getCompanyName());
+
+        assertEquals(REGISTER_LOCATION, pscJson.getRegisterLocation());
+        assertEquals(REGISTRATION_NUMBER, pscJson.getRegistrationNumber());
+        assertEquals(LAW_GOVERNED, pscJson.getLawGoverned());
+        assertEquals(LEGAL_FORM, pscJson.getLegalForm());
+
+        assertEquals(3, pscJson.getNaturesOfControl().length);
+        assertEquals("12", pscJson.getNaturesOfControl()[0]);
+        assertEquals("55", pscJson.getNaturesOfControl()[1]);
+        assertEquals("23", pscJson.getNaturesOfControl()[2]);
     }
 
     private PersonOfSignificantControl getPersonOfSignificantControl() {
@@ -179,7 +183,7 @@ class PscsMapperTest {
         psc.setOfficerDateOfBirth(OFFICER_DATE_OF_BIRTH);
         psc.setOfficerNationality(OFFICER_NATIONALITY);
         psc.setUsualResidentialCountry(USUAL_RESIDENTIAL_COUNTRY);
-        psc.setAppointmentTypeId(APPOINTMENT_TYPE_ID);
+        psc.setAppointmentTypeId(PSC_APPOINTMENT_TYPE_ID);
         psc.setAppointmentDate(APPOINTMENT_DATE);
         psc.setSuperSecurePscInd(SECURE_PSC_IND);
         psc.setSuppliedCompanyName(SUPPLIED_COMPANY_NAME);


### PR DESCRIPTION
The country of residence should be populated and sent to the web regardless of whether it is a psc or rle.