### PR TITLE
BI-10600 Escape path variables in validation logging

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
@@ -13,15 +13,14 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.COMPANY_NUMBER;
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.COMPANY_NUMBER_PATTERN;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.MAX_COMPANY_NUMBER_LENGTH;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.MAX_ID_LENGTH;
+import static uk.gov.companieshouse.confirmationstatementapi.utils.InputProcessor.sanitiseString;
 
 @Component
 public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
-
-    private static final Pattern COMPANY_NUMBER_PATTERN = Pattern.compile(
-            "^([a-z]|[a-z][a-z])?\\d{6,8}$", Pattern.CASE_INSENSITIVE);
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -39,7 +38,7 @@ public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
         var truncatedNumber = (companyNumber.length() > MAX_ID_LENGTH) ?
                 companyNumber.substring(0, MAX_ID_LENGTH) : companyNumber;
         var logMap = new HashMap<String, Object>();
-        logMap.put(COMPANY_NUMBER, truncatedNumber);
+        logMap.put(COMPANY_NUMBER, sanitiseString(truncatedNumber));
 
         if (companyNumber.length() != MAX_COMPANY_NUMBER_LENGTH) {
             ApiLogger.infoContext(reqId, "Company number length is invalid", logMap);

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/SubmissionIdValidationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/SubmissionIdValidationInterceptor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.CONFIRMATION_STATEMENT_ID_KEY;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.MAX_ID_LENGTH;
+import static uk.gov.companieshouse.confirmationstatementapi.utils.InputProcessor.sanitiseString;
 
 @Component
 public class SubmissionIdValidationInterceptor implements HandlerInterceptor {
@@ -34,8 +35,8 @@ public class SubmissionIdValidationInterceptor implements HandlerInterceptor {
         if (submissionId.length() > MAX_ID_LENGTH) {
             var truncatedUrlId = submissionId.substring(0, MAX_ID_LENGTH);
             var logMap = new HashMap<String, Object>();
-            logMap.put(CONFIRMATION_STATEMENT_ID_KEY, truncatedUrlId);
-            ApiLogger.infoContext(reqId, "Submission URL id exceeds " + MAX_ID_LENGTH + " characters.", logMap);
+            logMap.put(CONFIRMATION_STATEMENT_ID_KEY, sanitiseString(truncatedUrlId));
+            ApiLogger.infoContext(reqId, "Submission URL id exceeds " + MAX_ID_LENGTH + " characters", logMap);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/TransactionIdValidationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/TransactionIdValidationInterceptor.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID_KEY;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.MAX_ID_LENGTH;
 import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.confirmationstatementapi.utils.InputProcessor.sanitiseString;
 
 @Component
 public class TransactionIdValidationInterceptor implements HandlerInterceptor {
@@ -34,8 +35,8 @@ public class TransactionIdValidationInterceptor implements HandlerInterceptor {
         if (transactionId.length() > MAX_ID_LENGTH) {
             var truncatedUrlId = transactionId.substring(0, MAX_ID_LENGTH);
             var logMap = new HashMap<String, Object>();
-            logMap.put(TRANSACTION_ID_KEY, truncatedUrlId);
-            ApiLogger.infoContext(reqId, "Transaction URL id exceeds " + MAX_ID_LENGTH + " characters.", logMap);
+            logMap.put(TRANSACTION_ID_KEY, sanitiseString(truncatedUrlId));
+            ApiLogger.infoContext(reqId, "Transaction URL id exceeds " + MAX_ID_LENGTH + " characters", logMap);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/Constants.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.confirmationstatementapi.utils;
 
+import java.util.regex.Pattern;
+
 public class Constants {
 
     private Constants() {}
@@ -7,6 +9,11 @@ public class Constants {
     public static final int MAX_COMPANY_NUMBER_LENGTH = 8;
     public static final int MAX_ID_LENGTH = 50;
 
+    public static final Pattern COMPANY_NUMBER_PATTERN = Pattern.compile(
+            "^([a-z]|[a-z][a-z])?\\d{6,8}$", Pattern.CASE_INSENSITIVE);
+
+    public static final Pattern ID_PATTERN = Pattern.compile(
+            "[^A-Z|a-z|\\d| |-]");
 
     public static final String ERIC_REQUEST_ID_KEY = "X-Request-Id";
     public static final String TRANSACTION_ID_KEY = "transaction_id";

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/InputProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/utils/InputProcessor.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.confirmationstatementapi.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ID_PATTERN;
+
+public class InputProcessor {
+
+    public static String sanitiseString(String input) {
+        Matcher matcher = ID_PATTERN.matcher(input);
+        Set<String> allMatches = new HashSet<>();
+
+        while (matcher.find()) {
+            allMatches.add(matcher.group());
+        }
+
+        for(String unsafe : allMatches) {
+            input = input.replace(unsafe, "\\" + unsafe);
+        }
+        return input;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/utils/InputProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/utils/InputProcessorTest.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.confirmationstatementapi.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InputProcessorTest {
+
+    static Stream<String> validStrings() {
+        return Stream.of("019316-096616-323970",
+                "614c66f05c553622bfa4b90c",
+                "Transaction URL id exceeds 50 characters");
+    }
+
+    @ParameterizedTest
+    @MethodSource("validStrings")
+    void testValidIdStrings(String input) {
+        String processed = InputProcessor.sanitiseString(input);
+        assertEquals(input, processed);
+    }
+
+    @Test
+    void testXssStringIsEscaped() {
+        String input = "<script>foobarTheCode()</script>\tWhatever";
+        String processed = InputProcessor.sanitiseString(input);
+        assertEquals("\\<script\\>foobarTheCode\\(\\)\\<\\/script\\>\\\tWhatever", processed);
+    }
+}


### PR DESCRIPTION
Use an allow list and anything not on it will be escaped with a backslash. Not sure whether we should be introducing libraries here, OWasp says

_Do NOT simply encode/escape the list of example characters provided in the various rules. It is NOT sufficient to encode/escape only that list. Block list approaches are quite fragile. The allow list rules here have been carefully designed to provide protection even against future vulnerabilities introduced by browser changes._

However, this looks like it it is referring specifically to the lists on the webpage: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html

not the list provided in this PR.