### PR TITLE
BI-10714 Validate using new criteria

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
@@ -22,9 +22,6 @@ public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
     @Value("${MAX_ID_LENGTH}")
     private int maxIdLength;
 
-    @Value("${MAX_COMPANY_NUMBER_LENGTH}")
-    private int maxCompanyNumberLength;
-
     @Value("${COMPANY_NUMBER_PATTERN}")
     private String companyNumberPattern;
 
@@ -46,15 +43,10 @@ public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
         var logMap = new HashMap<String, Object>();
         logMap.put(COMPANY_NUMBER, truncatedNumber);
 
-        if (companyNumber.length() != maxCompanyNumberLength) {
-            ApiLogger.infoContext(reqId, "Company number length is invalid", logMap);
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            return false;
-        }
         var matcher = Pattern.compile(
-                companyNumberPattern, Pattern.CASE_INSENSITIVE).matcher(companyNumber);
+        companyNumberPattern).matcher(companyNumber);
         if(!matcher.find()){
-            ApiLogger.infoContext(reqId, "Company number contains invalid characters", logMap);
+            ApiLogger.infoContext(reqId, "Company number is either too long or contains invalid characters", logMap);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return false;
         }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptor.java
@@ -20,7 +20,7 @@ import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERI
 public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
 
     @Value("${MAX_ID_LENGTH}")
-    private int maxIdLength;
+    private int truncationLength;
 
     @Value("${COMPANY_NUMBER_PATTERN}")
     private String companyNumberPattern;
@@ -38,8 +38,8 @@ public class CompanyNumberValidationInterceptor implements HandlerInterceptor {
             return false;
         }
 
-        var truncatedNumber = (companyNumber.length() > maxIdLength) ?
-                companyNumber.substring(0, maxIdLength) : companyNumber;
+        var truncatedNumber = (companyNumber.length() > truncationLength) ?
+                companyNumber.substring(0, truncationLength) : companyNumber;
         var logMap = new HashMap<String, Object>();
         logMap.put(COMPANY_NUMBER, truncatedNumber);
 

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
@@ -32,7 +32,7 @@ class CompanyNumberValidationInterceptorTest {
     }
 
     static Stream<String> invalidStrings() {
-        return Stream.of("11111111111111111111111111", "AB11111111!", "$A111111", "1111111!");
+        return Stream.of("11111111111111111111111111", "AB11111111!", "$A111111", "1111111!", "10101010101");
     }
 
     @Mock
@@ -42,7 +42,7 @@ class CompanyNumberValidationInterceptorTest {
 
     @BeforeEach
     void setEnvironment() {
-        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "maxIdLength", 50);
+        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "truncationLength", 50);
         ReflectionTestUtils.setField(companyNumberValidationInterceptor, "companyNumberPattern", "^[A-Za-z0-9]{0,10}$");
     }
 

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
@@ -24,7 +24,7 @@ import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.COM
 class CompanyNumberValidationInterceptorTest {
 
     static Stream<String> validStrings() {
-        return Stream.of("11111111", "A1111111", "AB111111", "ab111111", "IP00366C", "1010101010");
+        return Stream.of("11111111", "A1111111", "AB111111", "ab111111", "IP00366C");
     }
 
     static Stream<String> blankStrings() {
@@ -32,7 +32,7 @@ class CompanyNumberValidationInterceptorTest {
     }
 
     static Stream<String> invalidStrings() {
-        return Stream.of("11111111111111111111111111", "AB11111111!", "$A111111", "1111111!", "10101010101");
+        return Stream.of("7777777", "999999999", "LONG1111111111111111111111", "AB11111111!", "$A111111", "1111111!");
     }
 
     @Mock
@@ -43,7 +43,7 @@ class CompanyNumberValidationInterceptorTest {
     @BeforeEach
     void setEnvironment() {
         ReflectionTestUtils.setField(companyNumberValidationInterceptor, "truncationLength", 50);
-        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "companyNumberPattern", "^[A-Za-z0-9]{0,10}$");
+        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "companyNumberPattern", "^[A-Za-z0-9]{8}$");
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/interceptor/validation/CompanyNumberValidationInterceptorTest.java
@@ -24,7 +24,7 @@ import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.COM
 class CompanyNumberValidationInterceptorTest {
 
     static Stream<String> validStrings() {
-        return Stream.of("11111111", "A1111111", "AB111111", "ab111111");
+        return Stream.of("11111111", "A1111111", "AB111111", "ab111111", "IP00366C", "1010101010");
     }
 
     static Stream<String> blankStrings() {
@@ -32,8 +32,7 @@ class CompanyNumberValidationInterceptorTest {
     }
 
     static Stream<String> invalidStrings() {
-        return Stream.of(
-                "1111111", "111111111", "A", "AB", "1", "ABCDEFGH", "AB11111111", "$A111111", "1111111!");
+        return Stream.of("11111111111111111111111111", "AB11111111!", "$A111111", "1111111!");
     }
 
     @Mock
@@ -44,8 +43,7 @@ class CompanyNumberValidationInterceptorTest {
     @BeforeEach
     void setEnvironment() {
         ReflectionTestUtils.setField(companyNumberValidationInterceptor, "maxIdLength", 50);
-        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "maxCompanyNumberLength", 8);
-        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "companyNumberPattern", "^([a-z]|[a-z][a-z])?\\d{6,8}$");
+        ReflectionTestUtils.setField(companyNumberValidationInterceptor, "companyNumberPattern", "^[A-Za-z0-9]{0,10}$");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Changed cirteria to validate company numbers that are alphanumeric and not over 10 characters long as the rpevious valaidation was to narrow.

Removed length check as the regex does this for us, altered error message slightly to allow for this.