### PR TITLE
Ecct 714 capture rea t3 post confirmation statement

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/SectionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/SectionStatus.java
@@ -3,5 +3,6 @@ package uk.gov.companieshouse.confirmationstatementapi.model;
 public enum SectionStatus {
     CONFIRMED,
     NOT_CONFIRMED,
-    RECENT_FILING
+    RECENT_FILING,
+    INITIAL_FILING
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
@@ -1,15 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.dao;
 
+import java.time.LocalDate;
+
 import org.springframework.data.mongodb.core.mapping.Field;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.SicCodeDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapital.StatementOfCapitalDataDao;
-
-import java.time.LocalDate;
 
 public class ConfirmationStatementSubmissionDataDao {
 
@@ -24,6 +26,9 @@ public class ConfirmationStatementSubmissionDataDao {
 
     @Field("registered_office_address_data")
     private RegisteredOfficeAddressDataDao registeredOfficeAddressData;
+
+    @Field("registered_email_address_data")
+    private RegisteredEmailAddressDataDao registeredEmailAddressData;
 
     @Field("active_officer_details_data")
     private ActiveOfficerDetailsDataDao activeOfficerDetailsData;
@@ -70,6 +75,14 @@ public class ConfirmationStatementSubmissionDataDao {
 
     public void setRegisteredOfficeAddressData(RegisteredOfficeAddressDataDao registeredOfficeAddressDataDao) {
         this.registeredOfficeAddressData = registeredOfficeAddressDataDao;
+    }
+
+    public RegisteredEmailAddressDataDao getRegisteredEmailAddressData() {
+        return registeredEmailAddressData;
+    }
+
+    public void setRegisteredEmailAddressData(RegisteredEmailAddressDataDao registeredEmailAddressData) {
+        this.registeredEmailAddressData = registeredEmailAddressData;
     }
 
     public ActiveOfficerDetailsDataDao getActiveOfficerDetailsData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/registeredemailaddress/RegisteredEmailAddressDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/registeredemailaddress/RegisteredEmailAddressDataDao.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.SectionDataDao;
+
+public class RegisteredEmailAddressDataDao extends SectionDataDao {
+
+    @Field("registered_email_address")
+    private String registeredEmailAddress;
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
@@ -1,16 +1,18 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.json;
 
+import java.time.LocalDate;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCodeDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalDataJson;
-
-import java.time.LocalDate;
 
 public class ConfirmationStatementSubmissionDataJson {
 
@@ -25,6 +27,9 @@ public class ConfirmationStatementSubmissionDataJson {
 
     @JsonProperty("registered_office_address_data")
     private RegisteredOfficeAddressDataJson registeredOfficeAddressData;
+
+    @JsonProperty("registered_email_address_data")
+    private RegisteredEmailAddressDataJson registeredEmailAddressData;
 
     @JsonProperty("active_officer_details_data")
     private ActiveOfficerDetailsDataJson activeOfficerDetailsData;
@@ -72,6 +77,14 @@ public class ConfirmationStatementSubmissionDataJson {
 
     public void setRegisteredOfficeAddressData(RegisteredOfficeAddressDataJson registeredOfficeAddressDataJson) {
         this.registeredOfficeAddressData = registeredOfficeAddressDataJson;
+    }
+
+    public RegisteredEmailAddressDataJson getRegisteredEmailAddressData() {
+        return registeredEmailAddressData;
+    }
+
+    public void setRegisteredEmailAddressData(RegisteredEmailAddressDataJson registeredEmailAddressData) {
+        this.registeredEmailAddressData = registeredEmailAddressData;
     }
 
     public ActiveOfficerDetailsDataJson getActiveOfficerDetailsData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressDataJson.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
+
+public class RegisteredEmailAddressDataJson extends SectionDataJson {
+
+    @JsonProperty("registered_email_address")
+    private String registeredEmailAddress;
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
@@ -1,11 +1,18 @@
 package uk.gov.companieshouse.confirmationstatementapi.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
@@ -16,6 +23,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapit
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
@@ -25,11 +33,6 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapi
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapperImpl;
-
-import java.time.LocalDate;
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonDaoMappingTest {
 
@@ -84,6 +87,8 @@ class JsonDaoMappingTest {
         SicCodeDao sicDao = sicDataDao.getSicCode();
         RegisteredOfficeAddressDataJson roaJson = json.getData().getRegisteredOfficeAddressData();
         RegisteredOfficeAddressDataDao roaDao = dao.getData().getRegisteredOfficeAddressData();
+        RegisteredEmailAddressDataJson reaJson = json.getData().getRegisteredEmailAddressData();
+        RegisteredEmailAddressDataDao reaDao = dao.getData().getRegisteredEmailAddressData();
         ActiveOfficerDetailsDataJson dirJson = json.getData().getActiveOfficerDetailsData();
         ActiveOfficerDetailsDataDao dirDao = dao.getData().getActiveOfficerDetailsData();
         ShareholderDataJson shareholderJson = json.getData().getShareholdersData();
@@ -99,6 +104,8 @@ class JsonDaoMappingTest {
         assertEquals(sicJson.getCode(), sicDao.getCode());
         assertEquals(sicJson.getDescription(), sicDao.getDescription());
         assertEquals(roaJson.getSectionStatus(), roaDao.getSectionStatus());
+        assertEquals(reaJson.getSectionStatus(), reaDao.getSectionStatus());
+        assertEquals(reaJson.getRegisteredEmailAddress(), reaDao.getRegisteredEmailAddress());
         assertEquals(dirJson.getSectionStatus(), dirDao.getSectionStatus());
         assertEquals(shareholderJson.getSectionStatus(), shareholderDao.getSectionStatus());
         assertEquals(rlJson.getSectionStatus(), rlDao.getSectionStatus());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
@@ -1,10 +1,14 @@
 package uk.gov.companieshouse.confirmationstatementapi.model;
 
+import java.time.LocalDate;
+import java.util.Collections;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonSignificantControlDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
@@ -17,6 +21,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDa
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonSignificantControlJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
@@ -24,9 +29,6 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCode
 import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCodeJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
-
-import java.time.LocalDate;
-import java.util.Collections;
 
 public class MockConfirmationStatementSubmissionData {
 
@@ -36,6 +38,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlJsonData());
         data.setSicCodeData(getSicCodeJsonData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressJsonData());
+        data.setRegisteredEmailAddressData(getRegisteredEmailAddressJsonData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsJsonData());
         data.setShareholdersData(getShareholdersJsonData());
         data.setRegisterLocationsData(getRegisterLocationsData());
@@ -96,6 +99,13 @@ public class MockConfirmationStatementSubmissionData {
         return registeredOfficeAddressData;
     }
 
+    private static RegisteredEmailAddressDataJson getRegisteredEmailAddressJsonData() {
+        var registeredEmailAddressData = new RegisteredEmailAddressDataJson();
+        registeredEmailAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
+
+        return registeredEmailAddressData;
+    }
+
     private static ActiveOfficerDetailsDataJson getActiveOfficerDetailsJsonData() {
         var activeDirectorDetailsData = new ActiveOfficerDetailsDataJson();
         activeDirectorDetailsData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
@@ -130,6 +140,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlDaoData());
         data.setSicCodeData(getSicCodeDaoData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressDaoData());
+        data.setRegisteredEmailAddressData(getRegisteredEmailAddressDaoData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsDaoData());
         data.setShareholdersData(getShareholdersDaoData());
         data.setRegisterLocationsData(getRegisterLocationsDaoData());
@@ -188,6 +199,13 @@ public class MockConfirmationStatementSubmissionData {
         registeredOfficeAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
 
         return registeredOfficeAddressData;
+    }
+
+    private static RegisteredEmailAddressDataDao getRegisteredEmailAddressDaoData() {
+        var registeredEmailAddressData = new RegisteredEmailAddressDataDao();
+        registeredEmailAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
+
+        return registeredEmailAddressData;
     }
 
     private static ActiveOfficerDetailsDataDao getActiveOfficerDetailsDaoData() {


### PR DESCRIPTION
Change comprises new and updated model objects for JSON and DAO to represent the REA for use in the POST and GET requests for the Confirmation Statement.

There are update JUnit tests and integration testing was performed using Postman in the CHS Dev Env.

No SonarLint warnings in the changeset and note this project has no Javadocs.