### PR TITLE
Ecct 165 Enhance Confirmation Statement service for REA

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -285,6 +285,45 @@
         }
       }
     },
+    "/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/registered-email-address": {
+      "parameters": [
+        {
+          "name": "transaction_id",
+          "in": "path",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "confirmation_statement_id",
+          "in": "path",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "summary": "Get the registered email address",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Registered Email Address"
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered email address",
+            "schema": {
+              "$ref": "#/definitions/RegisteredEmailAddress"
+            }
+          },
+          "400": {
+            "description": "A provided url id failed validation"
+          },
+          "401":{
+            "description": "Unauthorised"
+          }
+        }
+      }
+    },
     "/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/active-director-details": {
       "parameters": [
         {
@@ -589,6 +628,17 @@
             }
           }
         },
+        "registered_email_address_data": {
+          "type": "object",
+          "properties": {
+            "registered_email_address": {
+              "$ref" : "#/definitions/RegisteredEmailAddress"
+            },
+            "section_status": {
+              "$ref": "#/definitions/SectionStatusResponse"
+            }
+          }
+        },
         "active_officer_details_data": {
           "type": "object",
           "properties": {
@@ -863,6 +913,9 @@
         }
       }
     },
+    "RegisteredEmailAddress": {
+      "type": "string"
+    },
     "DateOfBirth": {
       "type": "object",
       "properties": {
@@ -1093,7 +1146,8 @@
       "enum": [
         "CONFIRMED",
         "NOT_CONFIRMED",
-        "RECENT_FILING"
+        "RECENT_FILING",
+        "INITIAL_FILING"
       ]
     }
   }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClient.java
@@ -1,32 +1,37 @@
 package uk.gov.companieshouse.confirmationstatementapi.client;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+
 import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapitalNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.PersonOfSignificantControl;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.ConfirmationStatementPaymentJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 
 @Component
 public class OracleQueryClient {
 
     private static final String CALLING_ORACLE_QUERY_API_URL_GET = "Calling Oracle Query API URL: %s";
-    public static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
+
+    private static final String ORACLE_QUERY_API_STATUS_MESSAGE = "Oracle query api returned with status = %s, companyNumber = %s";
+
+    private static final String ORACLE_QUERY_API_NO_DATA = "Oracle query api returned no data";
 
     @Autowired
     private RestTemplate restTemplate;
@@ -160,5 +165,23 @@ public class OracleQueryClient {
             throw new ServiceException("Oracle query api returned null for " + companyNumber + " with due date " + dueDate + ", boolean values expected");
         }
         return confirmationStatementPaymentJson.isPaid();
+    }
+
+    public String getRegisteredEmailAddress(String companyNumber) throws ServiceException {
+        var url = String.format("%s/company/%s/registered-email-address", oracleQueryApiUrl, companyNumber);
+        ApiLogger.info(String.format(CALLING_ORACLE_QUERY_API_URL_GET, url));
+
+        ResponseEntity<RegisteredEmailAddressJson> response = restTemplate.getForEntity(url, RegisteredEmailAddressJson.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) {
+            var body = response.getBody();
+            if (body != null) {
+                return body.getRegisteredEmailAddress();
+            } else {
+                throw new ServiceException(ORACLE_QUERY_API_NO_DATA);
+            }
+        } else {
+            throw new ServiceException(String.format(ORACLE_QUERY_API_STATUS_MESSAGE, response.getStatusCode(), companyNumber));
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EmailController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EmailController.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.ERIC_REQUEST_ID_KEY;
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.TRANSACTION_ID_KEY;
+
+import java.util.HashMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.service.EmailService;
+import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
+
+@RestController
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @Autowired
+    public EmailController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @GetMapping("/transactions/{transaction_id}/confirmation-statement/{confirmation_statement_id}/registered-email-address")
+    public ResponseEntity<String> getRegisteredEmailAddress(
+            @RequestAttribute("transaction") Transaction transaction,
+            @PathVariable(TRANSACTION_ID_KEY) String transactionId,
+            @RequestHeader(value = ERIC_REQUEST_ID_KEY) String requestId) {
+
+        var map = new HashMap<String, Object>();
+        map.put(TRANSACTION_ID_KEY, transactionId);
+
+        try {
+            ApiLogger.infoContext(requestId, "Calling service to retrieve registered email address", map);
+            var rea = emailService.getRegisteredEmailAddress(transaction.getCompanyNumber());
+            return ResponseEntity.status(HttpStatus.OK).body(rea);
+        } catch (ServiceException e) {
+            ApiLogger.errorContext(requestId,"Error retrieving shareholders data", e, map);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/SectionStatus.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/SectionStatus.java
@@ -3,5 +3,6 @@ package uk.gov.companieshouse.confirmationstatementapi.model;
 public enum SectionStatus {
     CONFIRMED,
     NOT_CONFIRMED,
-    RECENT_FILING
+    RECENT_FILING,
+    INITIAL_FILING
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
@@ -1,15 +1,17 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.dao;
 
+import java.time.LocalDate;
+
 import org.springframework.data.mongodb.core.mapping.Field;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.SicCodeDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapital.StatementOfCapitalDataDao;
-
-import java.time.LocalDate;
 
 public class ConfirmationStatementSubmissionDataDao {
 
@@ -24,6 +26,9 @@ public class ConfirmationStatementSubmissionDataDao {
 
     @Field("registered_office_address_data")
     private RegisteredOfficeAddressDataDao registeredOfficeAddressData;
+
+    @Field("registered_email_address_data")
+    private RegisteredEmailAddressDataDao registeredEmailAddressData;
 
     @Field("active_officer_details_data")
     private ActiveOfficerDetailsDataDao activeOfficerDetailsData;
@@ -70,6 +75,14 @@ public class ConfirmationStatementSubmissionDataDao {
 
     public void setRegisteredOfficeAddressData(RegisteredOfficeAddressDataDao registeredOfficeAddressDataDao) {
         this.registeredOfficeAddressData = registeredOfficeAddressDataDao;
+    }
+
+    public RegisteredEmailAddressDataDao getRegisteredEmailAddressData() {
+        return registeredEmailAddressData;
+    }
+
+    public void setRegisteredEmailAddressData(RegisteredEmailAddressDataDao registeredEmailAddressData) {
+        this.registeredEmailAddressData = registeredEmailAddressData;
     }
 
     public ActiveOfficerDetailsDataDao getActiveOfficerDetailsData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/registeredemailaddress/RegisteredEmailAddressDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/registeredemailaddress/RegisteredEmailAddressDataDao.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.SectionDataDao;
+
+public class RegisteredEmailAddressDataDao extends SectionDataDao {
+
+    @Field("registered_email_address")
+    private String registeredEmailAddress;
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
@@ -1,16 +1,18 @@
 package uk.gov.companieshouse.confirmationstatementapi.model.json;
 
+import java.time.LocalDate;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCodeDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalDataJson;
-
-import java.time.LocalDate;
 
 public class ConfirmationStatementSubmissionDataJson {
 
@@ -25,6 +27,9 @@ public class ConfirmationStatementSubmissionDataJson {
 
     @JsonProperty("registered_office_address_data")
     private RegisteredOfficeAddressDataJson registeredOfficeAddressData;
+
+    @JsonProperty("registered_email_address_data")
+    private RegisteredEmailAddressDataJson registeredEmailAddressData;
 
     @JsonProperty("active_officer_details_data")
     private ActiveOfficerDetailsDataJson activeOfficerDetailsData;
@@ -72,6 +77,14 @@ public class ConfirmationStatementSubmissionDataJson {
 
     public void setRegisteredOfficeAddressData(RegisteredOfficeAddressDataJson registeredOfficeAddressDataJson) {
         this.registeredOfficeAddressData = registeredOfficeAddressDataJson;
+    }
+
+    public RegisteredEmailAddressDataJson getRegisteredEmailAddressData() {
+        return registeredEmailAddressData;
+    }
+
+    public void setRegisteredEmailAddressData(RegisteredEmailAddressDataJson registeredEmailAddressData) {
+        this.registeredEmailAddressData = registeredEmailAddressData;
     }
 
     public ActiveOfficerDetailsDataJson getActiveOfficerDetailsData() {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressDataJson.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
+
+public class RegisteredEmailAddressDataJson extends SectionDataJson {
+
+    @JsonProperty("registered_email_address")
+    private String registeredEmailAddress;
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/registeredemailaddress/RegisteredEmailAddressJson.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RegisteredEmailAddressJson {
+
+    @JsonProperty("registered_email_address")
+    private String registeredEmailAddress;
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+    @Override
+    public String toString() {
+        return "RegisteredEmailAddress{" +
+                "registeredEmailAddress='" + registeredEmailAddress + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -1,9 +1,21 @@
 package uk.gov.companieshouse.confirmationstatementapi.service;
 
+import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.FILING_KIND_CS;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.transaction.Resource;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -21,31 +33,24 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationSta
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.NextMadeUpToDateJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.SectionDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.repository.ConfirmationStatementSubmissionsRepository;
 import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
 
-import java.net.URI;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Supplier;
-
-import static uk.gov.companieshouse.confirmationstatementapi.utils.Constants.FILING_KIND_CS;
-
 @Service
 public class ConfirmationStatementService {
 
-    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     @Value("${FEATURE_FLAG_ENABLE_PAYMENT_CHECK_26082021:true}")
     private boolean isPaymentCheckFeatureEnabled;
 
     @Value("${FEATURE_FLAG_VALIDATION_STATUS_02092021:true}")
     private boolean isValidationStatusEnabled;
+
+    @Value("${FEATURE_FLAG_ECCT_START_DATE_14082023:2024-02-05}")
+    private String ecctStartDateStr;
 
     private final CompanyProfileService companyProfileService;
     private final EligibilityService eligibilityService;
@@ -140,7 +145,7 @@ public class ConfirmationStatementService {
                                              Map<String, String> linksMap,
                                              LocalDate madeUpToDate, String companyNumber) throws ServiceException {
         if (!oracleQueryClient.isConfirmationStatementPaid(companyNumber,
-                madeUpToDate.format(dateTimeFormatter))) {
+                madeUpToDate.format(DATE_TIME_FORMATTER))) {
             String costsLink = createdUri + "/costs";
             linksMap.put("costs", costsLink);
         }
@@ -165,7 +170,7 @@ public class ConfirmationStatementService {
     public ValidationStatusResponse isValid(String submissionId) throws SubmissionNotFoundException {
         Optional<ConfirmationStatementSubmissionJson> submissionJsonOptional = getConfirmationStatement(submissionId);
 
-        if(submissionJsonOptional.isPresent()) {
+        if (submissionJsonOptional.isPresent()) {
             var validationStatus = new ValidationStatusResponse();
             ConfirmationStatementSubmissionJson submission = submissionJsonOptional.get();
             ConfirmationStatementSubmissionDataJson submissionData = submission.getData();
@@ -173,7 +178,6 @@ public class ConfirmationStatementService {
             if (submissionData == null) {
                 validationStatus.setValid(false);
             } else {
-
                 boolean isValid = isConfirmed(submissionData.getShareholdersData()) &&
                         isConfirmed(submissionData.getSicCodeData()) &&
                         isConfirmed(submissionData.getActiveOfficerDetailsData()) &&
@@ -181,10 +185,12 @@ public class ConfirmationStatementService {
                         isConfirmed(submissionData.getRegisteredOfficeAddressData()) &&
                         isConfirmed(submissionData.getPersonsSignificantControlData()) &&
                         isConfirmed(submissionData.getRegisterLocationsData()) &&
+                        isConfirmed(submissionData.getRegisteredEmailAddressData(), submissionData.getMadeUpToDate()) &&
                         Boolean.TRUE.equals(submissionData.getTradingStatusData().getTradingStatusAnswer()) &&
                         isBeforeOrEqual(localDateNow.get(), submissionData.getMadeUpToDate());
                 validationStatus.setValid(isValid);
             }
+
             if (!validationStatus.isValid()) {
                 var errors = new ValidationStatusError[1];
                 var error = new ValidationStatusError();
@@ -193,18 +199,33 @@ public class ConfirmationStatementService {
                 validationStatus.setValidationStatusError(errors);
             }
 
-
             return validationStatus;
         } else  {
-            throw new SubmissionNotFoundException(
-                String.format("Could not find submission data for submission %s", submissionId));
+            throw new SubmissionNotFoundException(String.format("Could not find submission data for submission %s", submissionId));
         }
     }
 
     private boolean isConfirmed(SectionDataJson sectionData) {
-        return sectionData != null &&
+        return (sectionData != null) &&
                 (sectionData.getSectionStatus() == SectionStatus.CONFIRMED ||
                  sectionData.getSectionStatus() == SectionStatus.RECENT_FILING);
+    }
+
+    private boolean isConfirmed(RegisteredEmailAddressDataJson sectionData, LocalDate madeUpToDate) {
+        if (isEcctEnabled(madeUpToDate)) {
+            return (sectionData != null) &&
+                    (sectionData.getSectionStatus() == SectionStatus.CONFIRMED ||
+                    sectionData.getSectionStatus() == SectionStatus.RECENT_FILING ||
+                    sectionData.getSectionStatus() == SectionStatus.INITIAL_FILING);
+        }
+
+        return true;
+    }
+
+    private boolean isEcctEnabled(LocalDate madeUpToDate) {
+        var ecctStartDate = LocalDate.parse(ecctStartDateStr, DATE_TIME_FORMATTER);
+
+        return isBeforeOrEqual(madeUpToDate, ecctStartDate);
     }
 
     public Optional<ConfirmationStatementSubmissionJson> getConfirmationStatement(String submissionId) {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/EmailService.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+
+@Service
+public class EmailService {
+
+    private final OracleQueryClient oracleQueryClient;
+
+    @Autowired
+    public EmailService(OracleQueryClient oracleQueryClient) {
+        this.oracleQueryClient = oracleQueryClient;
+    }
+
+    public String getRegisteredEmailAddress(String companyNumber) throws ServiceException {
+        return oracleQueryClient.getRegisteredEmailAddress(companyNumber);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/client/OracleQueryClientTest.java
@@ -1,5 +1,12 @@
 package uk.gov.companieshouse.confirmationstatementapi.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
+
 import uk.gov.companieshouse.api.model.common.Address;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ActiveOfficerNotFoundException;
 import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
@@ -17,16 +25,10 @@ import uk.gov.companieshouse.confirmationstatementapi.exception.StatementOfCapit
 import uk.gov.companieshouse.confirmationstatementapi.model.ActiveOfficerDetails;
 import uk.gov.companieshouse.confirmationstatementapi.model.PersonOfSignificantControl;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.payment.ConfirmationStatementPaymentJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OracleQueryClientTest {
@@ -280,5 +282,62 @@ class OracleQueryClientTest {
                 ConfirmationStatementPaymentJson.class )).thenReturn(response);
         assertThrows(ServiceException.class, () ->
                 oracleQueryClient.isConfirmationStatementPaid(COMPANY_NUMBER, "2022-01-01"));
+    }
+
+    @Test
+    void testGetRegisteredEmailAddress() throws ServiceException {
+        // GIVEN
+
+        var registeredEmailAddress = "info@acme.com";
+
+        var json = new RegisteredEmailAddressJson();
+        json.setRegisteredEmailAddress(registeredEmailAddress);
+
+        ResponseEntity<RegisteredEmailAddressJson> response = ResponseEntity.status(HttpStatus.OK).body(json);
+
+        var url = DUMMY_URL + "/company/" + COMPANY_NUMBER + "/registered-email-address";
+
+        // WHEN
+
+        when(restTemplate.getForEntity(url, RegisteredEmailAddressJson.class )).thenReturn(response);
+
+        // THEN
+
+        assertEquals(registeredEmailAddress, oracleQueryClient.getRegisteredEmailAddress(COMPANY_NUMBER));
+
+    }
+
+    @Test
+    void testGetRegisteredEmailAddressServiceUnavailable() throws ServiceException {
+        // GIVEN
+
+        ResponseEntity<RegisteredEmailAddressJson> response = ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(null);
+
+        var url = DUMMY_URL + "/company/" + COMPANY_NUMBER + "/registered-email-address";
+
+        // WHEN
+
+        when(restTemplate.getForEntity(url, RegisteredEmailAddressJson.class )).thenReturn(response);
+
+        // THEN
+
+        assertThrows(ServiceException.class, () -> oracleQueryClient.getRegisteredEmailAddress(COMPANY_NUMBER));
+    }
+
+    @Test
+    void testGetRegisteredEmailAddressNoBody() throws ServiceException {
+        // GIVEN
+
+        ResponseEntity<RegisteredEmailAddressJson> response = ResponseEntity.status(HttpStatus.OK).body(null);
+
+        var url = DUMMY_URL + "/company/" + COMPANY_NUMBER + "/registered-email-address";
+
+        // WHEN
+
+        when(restTemplate.getForEntity(url, RegisteredEmailAddressJson.class )).thenReturn(response);
+
+        // THEN
+
+        assertThrows(ServiceException.class, () -> oracleQueryClient.getRegisteredEmailAddress(COMPANY_NUMBER));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EmailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EmailControllerTest.java
@@ -1,0 +1,72 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+import uk.gov.companieshouse.confirmationstatementapi.service.EmailService;
+
+
+@ExtendWith(MockitoExtension.class)
+class EmailControllerTest {
+
+    private static final String TRANSACTION_ID = "GFEDCBA";
+
+    private static final String ERIC_REQUEST_ID = "XaBcDeF12345";
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private EmailController emailController;
+
+    @Test
+    void getRegisteredEmailAddress() throws ServiceException {
+        // GIVEN
+
+        var companyNumber = "12345ABCDE";
+        var registeredEmailAddress = "info@acme.com";
+
+        // WHEN
+
+        when(transaction.getCompanyNumber()).thenReturn(companyNumber);
+        when(emailService.getRegisteredEmailAddress(companyNumber)).thenReturn(registeredEmailAddress);
+
+        var response = emailController.getRegisteredEmailAddress(transaction, TRANSACTION_ID, ERIC_REQUEST_ID);
+
+        // THEN
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(registeredEmailAddress, response.getBody());
+    }
+
+    @Test
+    void getRegisteredEmailAddressServiceException() throws ServiceException {
+        // GIVEN
+
+        var companyNumber = "12345ABCDE";
+
+        // WHEN
+
+        when(transaction.getCompanyNumber()).thenReturn(companyNumber);
+        when(emailService.getRegisteredEmailAddress(companyNumber)).thenThrow(ServiceException.class);
+
+        var response = emailController.getRegisteredEmailAddress(transaction, TRANSACTION_ID, ERIC_REQUEST_ID);
+
+        // THEN
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
@@ -1,11 +1,18 @@
 package uk.gov.companieshouse.confirmationstatementapi.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
@@ -16,6 +23,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.dao.statementofcapit
 import uk.gov.companieshouse.confirmationstatementapi.model.json.ConfirmationStatementSubmissionJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
@@ -25,11 +33,6 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapi
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapper;
 import uk.gov.companieshouse.confirmationstatementapi.model.mapping.ConfirmationStatementJsonDaoMapperImpl;
-
-import java.time.LocalDate;
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonDaoMappingTest {
 
@@ -84,6 +87,8 @@ class JsonDaoMappingTest {
         SicCodeDao sicDao = sicDataDao.getSicCode();
         RegisteredOfficeAddressDataJson roaJson = json.getData().getRegisteredOfficeAddressData();
         RegisteredOfficeAddressDataDao roaDao = dao.getData().getRegisteredOfficeAddressData();
+        RegisteredEmailAddressDataJson reaJson = json.getData().getRegisteredEmailAddressData();
+        RegisteredEmailAddressDataDao reaDao = dao.getData().getRegisteredEmailAddressData();
         ActiveOfficerDetailsDataJson dirJson = json.getData().getActiveOfficerDetailsData();
         ActiveOfficerDetailsDataDao dirDao = dao.getData().getActiveOfficerDetailsData();
         ShareholderDataJson shareholderJson = json.getData().getShareholdersData();
@@ -99,6 +104,8 @@ class JsonDaoMappingTest {
         assertEquals(sicJson.getCode(), sicDao.getCode());
         assertEquals(sicJson.getDescription(), sicDao.getDescription());
         assertEquals(roaJson.getSectionStatus(), roaDao.getSectionStatus());
+        assertEquals(reaJson.getSectionStatus(), reaDao.getSectionStatus());
+        assertEquals(reaJson.getRegisteredEmailAddress(), reaDao.getRegisteredEmailAddress());
         assertEquals(dirJson.getSectionStatus(), dirDao.getSectionStatus());
         assertEquals(shareholderJson.getSectionStatus(), shareholderDao.getSectionStatus());
         assertEquals(rlJson.getSectionStatus(), rlDao.getSectionStatus());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
@@ -1,10 +1,14 @@
 package uk.gov.companieshouse.confirmationstatementapi.model;
 
+import java.time.LocalDate;
+import java.util.Collections;
+
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.ConfirmationStatementSubmissionDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.TradingStatusDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.activedirectordetails.ActiveOfficerDetailsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonSignificantControlDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.personsignificantcontrol.PersonsSignificantControlDataDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredemailaddress.RegisteredEmailAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registeredofficeaddress.RegisteredOfficeAddressDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.registerlocation.RegisterLocationsDataDao;
 import uk.gov.companieshouse.confirmationstatementapi.model.dao.shareholder.ShareholderDataDao;
@@ -17,6 +21,7 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.TradingStatusDa
 import uk.gov.companieshouse.confirmationstatementapi.model.json.activedirectordetails.ActiveOfficerDetailsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonSignificantControlJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.personsignificantcontrol.PersonsSignificantControlDataJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredemailaddress.RegisteredEmailAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registeredofficeaddress.RegisteredOfficeAddressDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.registerlocation.RegisterLocationsDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.shareholder.ShareholderDataJson;
@@ -24,9 +29,6 @@ import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCode
 import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.SicCodeJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalDataJson;
 import uk.gov.companieshouse.confirmationstatementapi.model.json.statementofcapital.StatementOfCapitalJson;
-
-import java.time.LocalDate;
-import java.util.Collections;
 
 public class MockConfirmationStatementSubmissionData {
 
@@ -36,6 +38,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlJsonData());
         data.setSicCodeData(getSicCodeJsonData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressJsonData());
+        data.setRegisteredEmailAddressData(getRegisteredEmailAddressJsonData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsJsonData());
         data.setShareholdersData(getShareholdersJsonData());
         data.setRegisterLocationsData(getRegisterLocationsData());
@@ -96,6 +99,13 @@ public class MockConfirmationStatementSubmissionData {
         return registeredOfficeAddressData;
     }
 
+    private static RegisteredEmailAddressDataJson getRegisteredEmailAddressJsonData() {
+        var registeredEmailAddressData = new RegisteredEmailAddressDataJson();
+        registeredEmailAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
+
+        return registeredEmailAddressData;
+    }
+
     private static ActiveOfficerDetailsDataJson getActiveOfficerDetailsJsonData() {
         var activeDirectorDetailsData = new ActiveOfficerDetailsDataJson();
         activeDirectorDetailsData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
@@ -130,6 +140,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setPersonsSignificantControlData(getPersonsSignificantControlDaoData());
         data.setSicCodeData(getSicCodeDaoData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressDaoData());
+        data.setRegisteredEmailAddressData(getRegisteredEmailAddressDaoData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsDaoData());
         data.setShareholdersData(getShareholdersDaoData());
         data.setRegisterLocationsData(getRegisterLocationsDaoData());
@@ -188,6 +199,13 @@ public class MockConfirmationStatementSubmissionData {
         registeredOfficeAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
 
         return registeredOfficeAddressData;
+    }
+
+    private static RegisteredEmailAddressDataDao getRegisteredEmailAddressDaoData() {
+        var registeredEmailAddressData = new RegisteredEmailAddressDataDao();
+        registeredEmailAddressData.setSectionStatus(SectionStatus.NOT_CONFIRMED);
+
+        return registeredEmailAddressData;
     }
 
     private static ActiveOfficerDetailsDataDao getActiveOfficerDetailsDaoData() {

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -98,6 +98,7 @@ class ConfirmationStatementServiceTest {
         confirmationStatementSubmissionJson.setId(SUBMISSION_ID);
         confirmationStatementSubmissionJson.setData(confirmationStatementSubmissionDataJson);
         ReflectionTestUtils.setField(confirmationStatementService, "isPaymentCheckFeatureEnabled", true);
+        ReflectionTestUtils.setField(confirmationStatementService, "ecctStartDateStr", "2018-02-05");
     }
 
     @Test
@@ -316,14 +317,124 @@ class ConfirmationStatementServiceTest {
 
     @Test
     void areTasksCompleteWithSomeRecentFiling() throws SubmissionNotFoundException {
+        // GIVEN
+
         makeAllMockTasksConfirmed();
         confirmationStatementSubmissionJson.getData().getPersonsSignificantControlData().setSectionStatus(SectionStatus.RECENT_FILING);
+        confirmationStatementSubmissionJson.getData().getRegisteredEmailAddressData().setSectionStatus(SectionStatus.RECENT_FILING);
         var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
         confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
+        when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
+        when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
+        when(localDateSupplier.get()).thenReturn(LocalDate.of(2021, 10, 12));
+
+        ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
+        assertTrue(validationStatusResponse.isValid());
+    }
+
+    @Test
+    void areTasksCompleteWithREANotConfirmed_madeUpBeforeDayOne() throws SubmissionNotFoundException {
+        // GIVEN
+
+        var ecctStartDateStr = ReflectionTestUtils.getField(confirmationStatementService, "ecctStartDateStr");
+        var ecctStartDate = LocalDate.parse((String) ecctStartDateStr, ConfirmationStatementService.DATE_TIME_FORMATTER);
+        var madeUpDate = ecctStartDate.minusDays(1);
+
+        makeAllMockTasksConfirmed();
+        confirmationStatementSubmissionJson.getData().setMadeUpToDate(madeUpDate);
+        confirmationStatementSubmissionJson.getData().getRegisteredEmailAddressData().setSectionStatus(SectionStatus.NOT_CONFIRMED);
+        var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
+        confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
+        when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
+        when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
+        when(localDateSupplier.get()).thenReturn(LocalDate.of(2021, 10, 12));
+
+        ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
+        assertTrue(validationStatusResponse.isValid());
+    }
+
+    @Test
+    void areTasksCompleteWithREANotConfirmed_madeUpOnDayOne() throws SubmissionNotFoundException {
+        // GIVEN
+
+        var ecctStartDateStr = ReflectionTestUtils.getField(confirmationStatementService, "ecctStartDateStr");
+        var ecctStartDate = LocalDate.parse((String) ecctStartDateStr, ConfirmationStatementService.DATE_TIME_FORMATTER);
+        var madeUpDate = ecctStartDate;
+
+        makeAllMockTasksConfirmed();
+        confirmationStatementSubmissionJson.getData().setMadeUpToDate(madeUpDate);
+        confirmationStatementSubmissionJson.getData().getRegisteredEmailAddressData().setSectionStatus(SectionStatus.NOT_CONFIRMED);
+        var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
+        confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
+        when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
+        when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
+
+        ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
+        assertFalse(validationStatusResponse.isValid());
+    }
+
+    @Test
+    void areTasksCompleteWithREANotConfirmed_madeUpAfterDayOne() throws SubmissionNotFoundException {
+        // GIVEN
+
+        var ecctStartDateStr = ReflectionTestUtils.getField(confirmationStatementService, "ecctStartDateStr");
+        var ecctStartDate = LocalDate.parse((String) ecctStartDateStr, ConfirmationStatementService.DATE_TIME_FORMATTER);
+        var madeUpDate = ecctStartDate.plusDays(1);
+
+        makeAllMockTasksConfirmed();
+        confirmationStatementSubmissionJson.getData().setMadeUpToDate(madeUpDate);
+        confirmationStatementSubmissionJson.getData().getRegisteredEmailAddressData().setSectionStatus(SectionStatus.NOT_CONFIRMED);
+        var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
+        confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
+        when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
+        when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
+
+        ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
+        assertFalse(validationStatusResponse.isValid());
+    }
+
+    @Test
+    void areTasksCompleteWithREAInitialFiling() throws SubmissionNotFoundException {
+        // GIVEN
+
+        makeAllMockTasksConfirmed();
+        confirmationStatementSubmissionJson.getData().getRegisteredEmailAddressData().setSectionStatus(SectionStatus.INITIAL_FILING);
+        var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
+        confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
         when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
         when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
         when(localDateSupplier.get()).thenReturn(LocalDate.of(2021, 10, 12));
         ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
         assertTrue(validationStatusResponse.isValid());
     }
 
@@ -336,6 +447,27 @@ class ConfirmationStatementServiceTest {
         when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
         when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
         ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+        assertFalse(validationStatusResponse.isValid());
+    }
+
+    @Test
+    void areTasksCompleteWithREANotPresent() throws SubmissionNotFoundException {
+        // GIVEN
+
+        makeAllMockTasksConfirmed();
+        confirmationStatementSubmissionJson.getData().setRegisteredEmailAddressData(null);
+        var confirmationStatementSubmission = new ConfirmationStatementSubmissionDao();
+        confirmationStatementSubmission.setId(SUBMISSION_ID);
+
+        // WHEN
+
+        when(confirmationStatementJsonDaoMapper.daoToJson(confirmationStatementSubmission)).thenReturn(confirmationStatementSubmissionJson);
+        when(confirmationStatementSubmissionsRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(confirmationStatementSubmission));
+
+        ValidationStatusResponse validationStatusResponse = confirmationStatementService.isValid(SUBMISSION_ID);
+
+        // THEN
+
         assertFalse(validationStatusResponse.isValid());
     }
 
@@ -518,6 +650,7 @@ class ConfirmationStatementServiceTest {
         data.getSicCodeData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getShareholdersData() .setSectionStatus(SectionStatus.CONFIRMED);
         data.getRegisteredOfficeAddressData().setSectionStatus(SectionStatus.CONFIRMED);
+        data.getRegisteredEmailAddressData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getPersonsSignificantControlData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getRegisterLocationsData().setSectionStatus(SectionStatus.CONFIRMED);
     }

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/EmailServiceTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.confirmationstatementapi.client.OracleQueryClient;
+import uk.gov.companieshouse.confirmationstatementapi.exception.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    private static final String COMPANY_NUMBER = "12345ABCDE";
+
+    @Mock
+    private OracleQueryClient oracleQueryClient;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Test
+    void getRegisteredEmailAddress() throws ServiceException {
+
+        // GIVEN
+
+        var registeredEmailAddress = "info@acme.com";
+
+        // WHEN
+
+        when(oracleQueryClient.getRegisteredEmailAddress(COMPANY_NUMBER)).thenReturn(registeredEmailAddress);
+
+        // THEN
+
+        assertEquals(registeredEmailAddress, emailService.getRegisteredEmailAddress(COMPANY_NUMBER));
+    }
+
+    @Test
+    void getRegisteredEmailAddressServiceException() throws ServiceException {
+
+        // WHEN
+
+        when(oracleQueryClient.getRegisteredEmailAddress(COMPANY_NUMBER)).thenThrow(ServiceException.class);
+
+        // THEN
+
+        assertThrows(ServiceException.class, () -> emailService.getRegisteredEmailAddress(COMPANY_NUMBER));
+    }
+
+}


### PR DESCRIPTION
This branch contains the amalgamated code changes for tasks:

- ECCT-728 "(ECCT-714) Update the Swagger API for the Confirmation Statement service"
- ECCT-716 "(ECCT-714) Implement a GET registered-email-address endpoint"
- ECCT-739 "(ECCT-714) Update the POST and GET confirmation-statement endpoint"
- ECCT-741 "(ECCT-714) Update the GET validation-status endpoint"

which comprise story ECCT-714 "Enhance Confirmation Statement API to handle registered email address".  Refer to the JIRA ticket for design and AC information.

These code changes have been stored in a feature branch for the service project for potential future utilisation depending on the enhancement plan for this service.
