### PR TITLE
ecct-779-fix-cs-api-incorrect-property

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/ConfirmationStatementSubmissionDataDao.java
@@ -80,11 +80,11 @@ public class ConfirmationStatementSubmissionDataDao {
         this.activeOfficerDetailsData = activeOfficerDetailsDataDao;
     }
 
-    public ShareholderDataDao getShareholdersData() {
+    public ShareholderDataDao getShareholderData() {
         return shareholderData;
     }
 
-    public void setShareholdersData(ShareholderDataDao shareholderDataDao) {
+    public void setShareholderData(ShareholderDataDao shareholderDataDao) {
         this.shareholderData = shareholderDataDao;
     }
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/ConfirmationStatementSubmissionDataJson.java
@@ -82,11 +82,11 @@ public class ConfirmationStatementSubmissionDataJson {
         this.activeOfficerDetailsData = activeOfficerDetailsData;
     }
 
-    public ShareholderDataJson getShareholdersData() {
+    public ShareholderDataJson getShareholderData() {
         return shareholderData;
     }
 
-    public void setShareholdersData(ShareholderDataJson shareholderData) {
+    public void setShareholderData(ShareholderDataJson shareholderData) {
         this.shareholderData = shareholderData;
     }
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementService.java
@@ -174,7 +174,7 @@ public class ConfirmationStatementService {
                 validationStatus.setValid(false);
             } else {
 
-                boolean isValid = isConfirmed(submissionData.getShareholdersData()) &&
+                boolean isValid = isConfirmed(submissionData.getShareholderData()) &&
                         isConfirmed(submissionData.getSicCodeData()) &&
                         isConfirmed(submissionData.getActiveOfficerDetailsData()) &&
                         isConfirmed(submissionData.getStatementOfCapitalData()) &&

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/JsonDaoMappingTest.java
@@ -86,8 +86,8 @@ class JsonDaoMappingTest {
         RegisteredOfficeAddressDataDao roaDao = dao.getData().getRegisteredOfficeAddressData();
         ActiveOfficerDetailsDataJson dirJson = json.getData().getActiveOfficerDetailsData();
         ActiveOfficerDetailsDataDao dirDao = dao.getData().getActiveOfficerDetailsData();
-        ShareholderDataJson shareholderJson = json.getData().getShareholdersData();
-        ShareholderDataDao shareholderDao = dao.getData().getShareholdersData();
+        ShareholderDataJson shareholderJson = json.getData().getShareholderData();
+        ShareholderDataDao shareholderDao = dao.getData().getShareholderData();
         RegisterLocationsDataJson rlJson = json.getData().getRegisterLocationsData();
         RegisterLocationsDataDao rlDao = dao.getData().getRegisterLocationsData();
         LocalDate madeUpToDateDao = dao.getData().getMadeUpToDate();

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/MockConfirmationStatementSubmissionData.java
@@ -37,7 +37,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setSicCodeData(getSicCodeJsonData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressJsonData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsJsonData());
-        data.setShareholdersData(getShareholdersJsonData());
+        data.setShareholderData(getShareholdersJsonData());
         data.setRegisterLocationsData(getRegisterLocationsData());
         data.setTradingStatusData(getTradingStatusJsonData());
         data.setMadeUpToDate(LocalDate.of(2021, 9, 12));
@@ -131,7 +131,7 @@ public class MockConfirmationStatementSubmissionData {
         data.setSicCodeData(getSicCodeDaoData());
         data.setRegisteredOfficeAddressData(getRegisteredOfficeAddressDaoData());
         data.setActiveOfficerDetailsData(getActiveOfficerDetailsDaoData());
-        data.setShareholdersData(getShareholdersDaoData());
+        data.setShareholderData(getShareholdersDaoData());
         data.setRegisterLocationsData(getRegisterLocationsDaoData());
         data.setMadeUpToDate(LocalDate.of(2021, 5, 12));
         data.setTradingStatusData(getTradingStatusDaoData());

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/ConfirmationStatementServiceTest.java
@@ -516,7 +516,7 @@ class ConfirmationStatementServiceTest {
         data.getActiveOfficerDetailsData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getStatementOfCapitalData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getSicCodeData().setSectionStatus(SectionStatus.CONFIRMED);
-        data.getShareholdersData() .setSectionStatus(SectionStatus.CONFIRMED);
+        data.getShareholderData() .setSectionStatus(SectionStatus.CONFIRMED);
         data.getRegisteredOfficeAddressData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getPersonsSignificantControlData().setSectionStatus(SectionStatus.CONFIRMED);
         data.getRegisterLocationsData().setSectionStatus(SectionStatus.CONFIRMED);


### PR DESCRIPTION
Fixes to typos on shareholder_data properties in the JSON and DAO mapping Java classes.

Existing JUnit test all pass.

Re-tested in CHS Dev Env using Postman and unwanted duplicated property shareholdersData was no longer present.