### PR TITLE
ecct-861-fix-npe-generate-filing-before-day-one

### DIFF
--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingService.java
@@ -76,7 +76,7 @@ public class FilingService {
             data.put("dtr5_ind", false);
 
             RegisteredEmailAddressDataJson registeredEmailAddressData = submissionData.getRegisteredEmailAddressData();
-            if (registeredEmailAddressData.getSectionStatus() == SectionStatus.INITIAL_FILING) {
+            if ((registeredEmailAddressData != null) && (registeredEmailAddressData.getSectionStatus() == SectionStatus.INITIAL_FILING)) {
                 data.put("registered_email_address", registeredEmailAddressData.getRegisteredEmailAddress());
             }
 


### PR DESCRIPTION
Need to check if the rea data in CS submission is null when generating the filing as this would be the case when operating before the Day One go-live date.  JUnit tests updated (test first).