### PR TITLE
Return 200 for all successful eligibility checks [ECCT-929]

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -232,16 +232,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The Company can use this service to file a Confirmation Statement",
+            "description": "The eligibility check was successful - response body indicates whether this company can use this service to file a Confirmation Statement",
             "schema": {
               "$ref": "#/definitions/CompanyValidationResponse"
             }
           },
           "400": {
-            "description": "The Company can not use this service to file a Confirmation Statement",
-            "schema": {
-              "$ref": "#/definitions/CompanyValidationResponse"
-            }
+            "description": "The provided Company Number failed validation"
+          },
+          "404": {
+            "description": "Company not found"
           }
         }
       }
@@ -686,7 +686,6 @@
     "EligibilityStatusCode": {
       "type": "string",
       "enum": [
-        "COMPANY_NOT_FOUND",
         "COMPANY_VALID_FOR_SERVICE",
         "INVALID_COMPANY_APPOINTMENTS_INVALID_NUMBER_OF_OFFICERS",
         "INVALID_COMPANY_APPOINTMENTS_MORE_THAN_ONE_PSC",
@@ -696,7 +695,8 @@
         "INVALID_COMPANY_TRADED_STATUS_USE_WEBFILING",
         "INVALID_COMPANY_TYPE_CS01_FILING_NOT_REQUIRED",
         "INVALID_COMPANY_TYPE_PAPER_FILING_ONLY",
-        "INVALID_COMPANY_TYPE_USE_WEB_FILING"
+        "INVALID_COMPANY_TYPE_USE_WEB_FILING",
+        "COMPANY_NOT_FOUND"
       ]
     },
     "CostsResponse": {

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityController.java
@@ -38,16 +38,11 @@ public class EligibilityController {
         try {
             var companyProfile = companyProfileService.getCompanyProfile(companyNumber);
             var companyValidationResponse = eligibilityService.checkCompanyEligibility(companyProfile);
-
-            if (EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE == companyValidationResponse.getEligibilityStatusCode()) {
-                return ResponseEntity.ok().body(companyValidationResponse);
-            } else {
-                return ResponseEntity.badRequest().body(companyValidationResponse);
-            }
+            return ResponseEntity.ok().body(companyValidationResponse);
         } catch (CompanyNotFoundException e) {
             var companyNotFoundResponse = new CompanyValidationResponse();
             companyNotFoundResponse.setEligibilityStatusCode(EligibilityStatusCode.COMPANY_NOT_FOUND);
-            return ResponseEntity.badRequest().body(companyNotFoundResponse);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(companyNotFoundResponse);
         } catch (Exception e) {
             ApiLogger.errorContext(requestId, "Error checking eligibility of company.", e, logMap);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/EligibilityControllerTest.java
@@ -46,7 +46,7 @@ class EligibilityControllerTest {
     }
 
     @Test
-    void testFailedGetEligibility() throws ServiceException, CompanyNotFoundException {
+    void testNotEligibleGetEligibility() throws ServiceException, CompanyNotFoundException {
         CompanyProfileApi companyProfileApi = new CompanyProfileApi();
         companyProfileApi.setCompanyStatus("FailureValue");
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
@@ -54,7 +54,7 @@ class EligibilityControllerTest {
         companyValidationResponse.setEligibilityStatusCode(EligibilityStatusCode.INVALID_COMPANY_STATUS);
         when(eligibilityService.checkCompanyEligibility(companyProfileApi)).thenReturn(companyValidationResponse);
         ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
-        assertEquals(400, response.getStatusCodeValue());
+        assertEquals(200, response.getStatusCodeValue());
     }
 
     @Test
@@ -75,7 +75,7 @@ class EligibilityControllerTest {
     void testCompanyNotFound() throws ServiceException, CompanyNotFoundException {
         when(companyProfileService.getCompanyProfile(COMPANY_NUMBER)).thenThrow(new CompanyNotFoundException());
         ResponseEntity<CompanyValidationResponse> response = eligibilityController.getEligibility(COMPANY_NUMBER, ERIC_REQUEST_ID);
-        assertEquals(400, response.getStatusCodeValue());
+        assertEquals(404, response.getStatusCodeValue());
         assertNotNull(response.getBody());
         assertEquals(EligibilityStatusCode.COMPANY_NOT_FOUND, response.getBody().getEligibilityStatusCode());
     }


### PR DESCRIPTION
Changes to avoid successful check responses for non-eligible companies being caught by web error handling, so that dedicated "You cannot use this service" screen is shown instead.
- return 200 for successful check even when company is not eligible
- return 404 when company is not found
- update unit tests & specs (including re-ordering status enum so highlighted example is most relevant value)