### PR TITLE
Fix security vulnerabilities (commons-lang 2.6, tomcat-embed-core) & upgraded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,22 +16,22 @@
         <java.version>21</java.version>
         <spring-boot-starter.version>3.5.3</spring-boot-starter.version>
         <spring-context.version>6.2.10</spring-context.version>
-        <api-sdk-java.version>6.3.5</api-sdk-java.version>
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <api-sdk-java.version>6.4.1</api-sdk-java.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <tomcat-embed-core.version>11.0.9</tomcat-embed-core.version>
+        <tomcat-embed-core.version>11.0.10</tomcat-embed-core.version>
         <spring-web.version>6.2.10</spring-web.version>
-        <private-api-sdk-java.version>4.0.328</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.337</private-api-sdk-java.version>
         <api-security-java.version>2.0.10</api-security-java.version>
-        <api-sdk-manager-java-library.version>3.0.9</api-sdk-manager-java-library.version>
+        <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
         <structured-logging.version>3.0.40</structured-logging.version>
         <apache-log4j.version>2.25.1</apache-log4j.version>
         <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <opentelemetry-version>2.14.0</opentelemetry-version>
-
+        <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
 
         <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
         <sonar.login></sonar.login>
@@ -88,6 +88,36 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
                 <version>${tomcat-embed-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat-embed-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat-embed-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -154,6 +184,12 @@
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/FilingServiceTest.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
- Excluded vulnerable commons-lang 2.6
- Upgraded tomcat-embed-core to 11.0.10
- private-api-sdk-java → 4.0.337
- api-sdk-manager-java-library → 3.0.10
- api-sdk-java-library → 6.4.1
- maven-compiler-plugin → 3.14.0