### PR TITLE
CSE-1367: ACSP Pull Condensed SIC Code List directly from MongoDB using CS API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
 

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/ConfirmationStatementApiApplication.java
@@ -3,10 +3,14 @@ package uk.gov.companieshouse.confirmationstatementapi;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableCaching
+@EnableScheduling
 public class ConfirmationStatementApiApplication {
 
 	public static final String APP_NAMESPACE = "confirmation-statement-api";

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/InterceptorConfig.java
@@ -31,10 +31,12 @@ public class InterceptorConfig implements WebMvcConfigurer {
     private static final String NEXT_MADE_UP_TO_DATE = "/confirmation-statement/**/next-made-up-to-date";
     private static final String ELIGIBILITY = "/confirmation-statement/**/eligibility";
     private static final String COSTS = TRANSACTIONS + "/costs";
+    private static final String CONDENSED_SIC_CODES = "/confirmation-statement/condensed-sic-codes";
 
     static final String[] USER_AUTH_ENDPOINTS = {
         NEXT_MADE_UP_TO_DATE,
-        ELIGIBILITY
+        ELIGIBILITY,
+        CONDENSED_SIC_CODES
     };
     static final String[] INTERNAL_AUTH_ENDPOINTS = {
         PRIVATE,

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/MongoConfig.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/configuration/MongoConfig.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.confirmationstatementapi.configuration;
+
+import com.mongodb.client.MongoClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+
+@Configuration
+public class MongoConfig {
+
+    @Bean(name = "mongoTemplate")
+    @Primary
+    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+        return new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoClient, "transaction_confirmation_statement_submissions"));
+    }
+
+    @Bean(name = "condensedSicCodeMongoTemplate")
+    public MongoTemplate condensedSicCodeMongoTemplate(MongoClient mongoClient) {
+        return new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoClient, "sic_code"));
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeController.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeController.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.confirmationstatementapi.service.CondensedSicCodeService;
+import uk.gov.companieshouse.confirmationstatementapi.utils.ApiLogger;
+
+@RestController
+@RequestMapping("/confirmation-statement/condensed-sic-codes")
+public class CondensedSicCodeController {
+
+    private final CondensedSicCodeService condensedSicCodeService;
+
+    @Autowired
+    public CondensedSicCodeController(CondensedSicCodeService condensedSicCodeService) {
+        this.condensedSicCodeService = condensedSicCodeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getCondensedSicCodeList() {
+        ApiLogger.info("Calling service to retrieve full condensed sic code list");
+
+        return ResponseEntity.ok(condensedSicCodeService.getCondensedSicCodeList());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/siccode/CondensedSicCodeDao.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/dao/siccode/CondensedSicCodeDao.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.TextIndexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "condensed_sic_codes")
+public class CondensedSicCodeDao {
+
+    @Id
+    @Field("_id")
+    private String id;
+
+    @TextIndexed
+    @Field("sic_code")
+    private String sicCode;
+
+    @Field("sic_description")
+    private String sicDescription;
+
+    public CondensedSicCodeDao() {
+    }
+
+    public CondensedSicCodeDao(String id, String sicCode, String sicDescription) {
+        this.id = id;
+        this.sicCode = sicCode;
+        this.sicDescription = sicDescription;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSicCode() {
+        return sicCode;
+    }
+
+    public void setSicCode(String sicCode) {
+        this.sicCode = sicCode;
+    }
+
+    public String getSicDescription() {
+        return sicDescription;
+    }
+
+    public void setSicDescription(String sicDescription) {
+        this.sicDescription = sicDescription;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/siccode/CondensedSicCodeJson.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/json/siccode/CondensedSicCodeJson.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.json.siccode;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CondensedSicCodeJson {
+    @JsonProperty("sic_code")
+    private String sicCode;
+
+    @JsonProperty("sic_description")
+    private String sicDescription;
+
+    public CondensedSicCodeJson() {
+    }
+
+    public CondensedSicCodeJson(String sicCode, String sicDescription) {
+        this.sicCode = sicCode;
+        this.sicDescription = sicDescription;
+    }
+
+    public String getSicCode() {
+        return sicCode;
+    }
+
+    public void setSicCode(String sicCode) {
+        this.sicCode = sicCode;
+    }
+
+    public String getSicDescription() {
+        return sicDescription;
+    }
+
+    public void setSicDescription(String sicDescription) {
+        this.sicDescription = sicDescription;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMapper.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMapper.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.mapping;
+
+import org.mapstruct.Mapper;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.CondensedSicCodeDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.CondensedSicCodeJson;
+
+import java.util.List;
+
+@Mapper
+public interface CondensedSicCodeMapper {
+
+    List<CondensedSicCodeJson> daoToJson(List<CondensedSicCodeDao> condensedSicCodeDaoList);
+}

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeService.java
@@ -40,6 +40,8 @@ public class CondensedSicCodeService {
 
     @CacheEvict(value = "condensedSicCodeList", allEntries = true)
     @Scheduled(fixedRate = 12, timeUnit = TimeUnit.HOURS)
-    public void cacheEvict() {}
+    public void cacheEvict() {
+        // Cache eviction is handled by @CacheEvic
+    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeService.java
+++ b/src/main/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeService.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.CondensedSicCodeDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.CondensedSicCodeJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.mapping.CondensedSicCodeMapper;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class CondensedSicCodeService {
+    private final MongoTemplate condensedSicCodeMongoTemplate;
+
+    private final CondensedSicCodeMapper condensedSicCodeMapper;
+
+    @Autowired
+    public CondensedSicCodeService(@Qualifier("condensedSicCodeMongoTemplate")
+                                   MongoTemplate condensedSicCodeMongoTemplate,
+                                   CondensedSicCodeMapper condensedSicCodeMapper) {
+        this.condensedSicCodeMongoTemplate = condensedSicCodeMongoTemplate;
+        this.condensedSicCodeMapper = condensedSicCodeMapper;
+    }
+
+    @Cacheable("condensedSicCodeList")
+    public List<CondensedSicCodeJson> getCondensedSicCodeList() {
+
+        List<CondensedSicCodeDao> condensedSicCodeDaoList = condensedSicCodeMongoTemplate.findAll(CondensedSicCodeDao.class);
+
+        return condensedSicCodeMapper.daoToJson(condensedSicCodeDaoList);
+    }
+
+
+    @CacheEvict(value = "condensedSicCodeList", allEntries = true)
+    @Scheduled(fixedRate = 12, timeUnit = TimeUnit.HOURS)
+    public void cacheEvict() {}
+
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/configuration/MongoConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/configuration/MongoConfigTest.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.confirmationstatementapi.configuration;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class MongoConfigTest {
+
+    @Autowired
+    @Qualifier("mongoTemplate")
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    @Qualifier("condensedSicCodeMongoTemplate")
+    private MongoTemplate condensedSicCodeMongoTemplate;
+
+    @Test
+    void shouldLoadMongoTemplate() {
+        assertNotNull(mongoTemplate);
+    }
+
+    @Test
+    void shouldLoadTestCodeMongoTemplate() {
+        assertNotNull(condensedSicCodeMongoTemplate);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeControllerTest.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.confirmationstatementapi.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.CondensedSicCodeJson;
+import uk.gov.companieshouse.confirmationstatementapi.service.CondensedSicCodeService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CondensedSicCodeControllerTest {
+
+    @Mock
+    private CondensedSicCodeService condensedSicCodeService;
+
+    @InjectMocks
+    private CondensedSicCodeController condensedSicCodeController;
+
+    @Test
+    void testSuccessfulGetCondensedSicCodeList() {
+
+        // GIVEN
+        when(condensedSicCodeService.getCondensedSicCodeList()).thenReturn(getMockCondensedSicCodeList());
+
+        // When
+        ResponseEntity<Object> response = condensedSicCodeController.getCondensedSicCodeList();
+
+        // Then
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals(((List<CondensedSicCodeJson>) response.getBody()).size(), 2);
+    }
+
+    private List<CondensedSicCodeJson> getMockCondensedSicCodeList() {
+        return Arrays.asList(new CondensedSicCodeJson("17110", "Manufacture of pulp"),
+                new CondensedSicCodeJson("20301", "Manufacture of paints"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/controller/CondensedSicCodeControllerTest.java
@@ -37,7 +37,7 @@ class CondensedSicCodeControllerTest {
         // Then
         assertEquals(200, response.getStatusCode().value());
         assertNotNull(response.getBody());
-        assertEquals(((List<CondensedSicCodeJson>) response.getBody()).size(), 2);
+        assertEquals(2, ((List<CondensedSicCodeJson>) response.getBody()).size());
     }
 
     private List<CondensedSicCodeJson> getMockCondensedSicCodeList() {

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMappingTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-public class CondensedSicCodeMappingTest {
+class CondensedSicCodeMappingTest {
 
     @Autowired
     private CondensedSicCodeMapper condensedSicCodeMapper;
@@ -26,15 +26,25 @@ public class CondensedSicCodeMappingTest {
 
     @Test
     void testValidMappingForSicCodes() {
+        CondensedSicCodeDao condensedSicCodeDao1 = new CondensedSicCodeDao();
+        condensedSicCodeDao1.setId(SIC_CODE_ID_13922);
+        condensedSicCodeDao1.setSicCode(SIC_CODE_13922);
+        condensedSicCodeDao1.setSicDescription(SIC_DESCRIPTION_13922);
+
+        CondensedSicCodeDao condensedSicCodeDao2 = new CondensedSicCodeDao();
+        condensedSicCodeDao2.setId(SIC_CODE_ID_13950);
+        condensedSicCodeDao2.setSicCode(SIC_CODE_13950);
+        condensedSicCodeDao2.setSicDescription(SIC_DESCRIPTION_13950);
+
         List<CondensedSicCodeDao> condensedSicCodeDaoList = Arrays.asList(
-                new CondensedSicCodeDao(SIC_CODE_ID_13922, SIC_CODE_13922, SIC_DESCRIPTION_13922),
-                new CondensedSicCodeDao(SIC_CODE_ID_13950, SIC_CODE_13950, SIC_DESCRIPTION_13950));
+                condensedSicCodeDao1,
+                condensedSicCodeDao2);
 
         List<CondensedSicCodeJson> condensedSicCodeJsonList = condensedSicCodeMapper.daoToJson(condensedSicCodeDaoList);
 
         assertNotNull(condensedSicCodeJsonList);
-        assertEquals(condensedSicCodeJsonList.size(), 2);
-        assertEquals(condensedSicCodeJsonList.get(0).getSicDescription(), "manufacture of canvas goods");
+        assertEquals(2, condensedSicCodeJsonList.size());
+        assertEquals("manufacture of canvas goods", condensedSicCodeJsonList.get(0).getSicDescription());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMappingTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/model/mapping/CondensedSicCodeMappingTest.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.confirmationstatementapi.model.mapping;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.CondensedSicCodeDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.CondensedSicCodeJson;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class CondensedSicCodeMappingTest {
+
+    @Autowired
+    private CondensedSicCodeMapper condensedSicCodeMapper;
+
+    private static final String SIC_CODE_ID_13922 = "id-13922";
+    private static final String SIC_CODE_13922 = "13922";
+    private static final String SIC_DESCRIPTION_13922 = "manufacture of canvas goods";
+    private static final String SIC_CODE_ID_13950 = "id-13950";
+    private static final String SIC_CODE_13950 = "13950";
+    private static final String SIC_DESCRIPTION_13950 = "Manufacture of non-wovens and articles made from non-wovens";
+
+    @Test
+    void testValidMappingForSicCodes() {
+        List<CondensedSicCodeDao> condensedSicCodeDaoList = Arrays.asList(
+                new CondensedSicCodeDao(SIC_CODE_ID_13922, SIC_CODE_13922, SIC_DESCRIPTION_13922),
+                new CondensedSicCodeDao(SIC_CODE_ID_13950, SIC_CODE_13950, SIC_DESCRIPTION_13950));
+
+        List<CondensedSicCodeJson> condensedSicCodeJsonList = condensedSicCodeMapper.daoToJson(condensedSicCodeDaoList);
+
+        assertNotNull(condensedSicCodeJsonList);
+        assertEquals(condensedSicCodeJsonList.size(), 2);
+        assertEquals(condensedSicCodeJsonList.get(0).getSicDescription(), "manufacture of canvas goods");
+    }
+
+    @Test
+    void testSicCodeNullList() {
+        List<CondensedSicCodeJson> result = condensedSicCodeMapper.daoToJson(null);
+        assertNull(result);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeServiceTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class CondensedSicCodeServiceTest {
+class CondensedSicCodeServiceTest {
 
     @Mock
     private MongoTemplate condensedSicCodeMongoTemplate;

--- a/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/confirmationstatementapi/service/CondensedSicCodeServiceTest.java
@@ -1,0 +1,92 @@
+package uk.gov.companieshouse.confirmationstatementapi.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.gov.companieshouse.confirmationstatementapi.model.dao.siccode.CondensedSicCodeDao;
+import uk.gov.companieshouse.confirmationstatementapi.model.json.siccode.CondensedSicCodeJson;
+import uk.gov.companieshouse.confirmationstatementapi.model.mapping.CondensedSicCodeMapper;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CondensedSicCodeServiceTest {
+
+    @Mock
+    private MongoTemplate condensedSicCodeMongoTemplate;
+
+    @Mock
+    private CondensedSicCodeMapper condensedSicCodeMapper;
+
+    @InjectMocks
+    private CondensedSicCodeService condensedSicCodeService;
+
+    private static final String SIC_CODE_ID_10120 = "id-10120";
+    private static final String SIC_CODE_10120 = "10120";
+    private static final String SIC_DESCRIPTION_10120 = "Processing and preserving of poultry meat";
+    private static final String SIC_CODE_ID_10511 = "id-10511";
+    private static final String SIC_CODE_10511 = "10511";
+    private static final String SIC_DESCRIPTION_10511 = "Liquid milk and cream production";
+
+    @Test
+    void shouldReturnCondensedSicCodeList() {
+        // GIVEN
+        List<CondensedSicCodeDao> condensedSicCodeDaoList = getMockCondensedSicCodeDaoList();
+        when(condensedSicCodeMongoTemplate.findAll(CondensedSicCodeDao.class)).thenReturn(condensedSicCodeDaoList);
+        when(condensedSicCodeMapper.daoToJson(condensedSicCodeDaoList)).thenReturn(getMockCondensedSicCodeJsonList());
+
+        // When
+        List<CondensedSicCodeJson> result = condensedSicCodeService.getCondensedSicCodeList();
+
+        // Then
+        verify(condensedSicCodeMongoTemplate, times(1))
+                .findAll(CondensedSicCodeDao.class);
+        verify(condensedSicCodeMapper, times(1))
+                .daoToJson(condensedSicCodeDaoList);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("10120", result.get(0).getSicCode());
+    }
+
+    @Test
+    void shouldReturnNullSicCodeListWhenNoSicCodeInDb() {
+        // GIVEN
+        when(condensedSicCodeMongoTemplate.findAll(CondensedSicCodeDao.class)).thenReturn(null);
+        when(condensedSicCodeMapper.daoToJson(null)).thenReturn(null);
+
+        // When
+        List<CondensedSicCodeJson> result = condensedSicCodeService.getCondensedSicCodeList();
+
+        // Then
+        verify(condensedSicCodeMongoTemplate, times(1))
+                .findAll(CondensedSicCodeDao.class);
+        verify(condensedSicCodeMapper, times(1))
+                .daoToJson(null);
+        assertNull(result);
+    }
+
+    @Test
+    void shouldExecuteCacheEvict() {
+        assertDoesNotThrow(() -> condensedSicCodeService.cacheEvict());
+    }
+
+    private List<CondensedSicCodeDao> getMockCondensedSicCodeDaoList() {
+        return Arrays.asList(new CondensedSicCodeDao(SIC_CODE_ID_10120, SIC_CODE_10120, SIC_DESCRIPTION_10120),
+                new CondensedSicCodeDao(SIC_CODE_ID_10511, SIC_CODE_10511, SIC_DESCRIPTION_10511));
+    }
+
+    private List<CondensedSicCodeJson> getMockCondensedSicCodeJsonList() {
+        return Arrays.asList(new CondensedSicCodeJson(SIC_CODE_10120, SIC_DESCRIPTION_10120),
+                new CondensedSicCodeJson(SIC_CODE_10511, SIC_DESCRIPTION_10511));
+    }
+
+}


### PR DESCRIPTION
Ticket:
https://companieshouse.atlassian.net/browse/CSE-1367

Changes:
- Add API Call to retrieve the condensed sic code list from Confirmation Statement API
- Enable caching and scheduling for condensedSicCodeList
- Set condensedSicCodeList for 12 hours in cache
- Update the interceptor to validate the new API call with using user authentication 
- Add the unit test for the changes