### PR TITLE
ASM-2691 Update parent pom.xml to version 2.1.15 and enhance dependency management with new properties and updated versions for various libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.14</version>
+        <version>2.1.15</version>
     </parent>
 
     <artifactId>confirmation-statement-api</artifactId>
@@ -22,8 +22,77 @@
         </profile>
     </profiles>
 
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Plugin Versions -->
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
+        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+
+        <!-- Companies House Internal Dependency Versions -->
+        <!-- Source: https://github.com/companieshouse/api-sdk-java/releases -->
+        <api-sdk-java.version>7.2.1</api-sdk-java.version>
+        <!-- Source: https://github.com/companieshouse/private-api-sdk-java/releases -->
+        <private-api-sdk-java.version>7.2.1</private-api-sdk-java.version>
+        <!-- Source: https://github.com/companieshouse/api-security-java/releases -->
+        <api-security-java.version>2.0.27</api-security-java.version>
+        <!-- Source: https://github.com/companieshouse/api-sdk-manager-java-library/releases -->
+        <api-sdk-manager-java-library.version>3.0.28</api-sdk-manager-java-library.version>
+        <!-- Source: https://github.com/companieshouse/structured-logging/releases -->
+        <structured-logging.version>3.0.57</structured-logging.version>
+
+        <!-- Dependency Versions -->
+        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
+        <spring-boot.version>4.1.0</spring-boot.version>
+        <!-- Source: https://mvnrepository.com/artifact/tools.jackson.core/jackson-core -->
+        <jackson3.version>3.2.1</jackson3.version>
+        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
+        <opentelemetry.version>2.29.0</opentelemetry.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
+        <log4j-bom.version>2.26.1</log4j-bom.version>
+        <!-- Source: https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <guava.version>33.6.0-jre</guava.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <!-- Source: https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils -->
+        <plexus-utils.version>4.0.3</plexus-utils.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
+        <kotlin.version>2.3.21</kotlin.version>
+        <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
+        <tomcat.version>11.0.24</tomcat.version>
+
+        <!-- Sonar Properties        -->
+        <!--suppress XmlUnresolvedReference -->
+        <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
+        <sonar.projectName>confirmation-statement-api</sonar.projectName>
+        <sonar.projectKey>uk.gov.companieshouse:confirmation-statement-api</sonar.projectKey>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+
+            <!-- This should be upgraded to 4.36.0 when available, currently at RC1 -->
+            <!-- This will avoid `WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil` -->
+            <!-- Source: https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>4.35.1</version>
+                <scope>compile</scope>
+            </dependency>
 
             <dependency>
                 <groupId>tools.jackson.core</groupId>
@@ -36,7 +105,16 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -53,7 +131,7 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-context</artifactId>
-                <version>1.82.1</version>
+                <version>1.82.2</version>
                 <scope>compile</scope>
             </dependency>
 
@@ -91,6 +169,22 @@
                 <scope>compile</scope>
             </dependency>
 
+            <!-- BEGIN CVE OVERRIDE          -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <!-- END CVE           -->
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -101,66 +195,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <properties>
-        <java.version>21</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <!-- Plugin Versions -->
-        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
-        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-        <!-- Source: https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
-        <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin -->
-        <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
-
-        <!-- Companies House Internal Dependency Versions -->
-        <!-- Source: https://github.com/companieshouse/api-sdk-java/releases -->
-        <api-sdk-java.version>7.0.5</api-sdk-java.version>
-        <!-- Source: https://github.com/companieshouse/private-api-sdk-java/releases -->
-        <private-api-sdk-java.version>7.0.4</private-api-sdk-java.version>
-        <!-- Source: https://github.com/companieshouse/api-security-java/releases -->
-        <api-security-java.version>2.0.27</api-security-java.version>
-        <!-- Source: https://github.com/companieshouse/api-sdk-manager-java-library/releases -->
-        <api-sdk-manager-java-library.version>3.0.24</api-sdk-manager-java-library.version>
-        <!-- Source: https://github.com/companieshouse/structured-logging/releases -->
-        <structured-logging.version>3.0.57</structured-logging.version>
-
-        <!-- Dependency Versions -->
-        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
-        <spring-boot.version>4.1.0</spring-boot.version>
-        <!-- Source: https://mvnrepository.com/artifact/tools.jackson.core/jackson-core -->
-        <jackson3.version>3.2.0</jackson3.version>
-        <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
-        <opentelemetry.version>2.29.0</opentelemetry.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
-        <log4j-bom.version>2.26.0</log4j-bom.version>
-        <!-- Source: https://mvnrepository.com/artifact/com.google.guava/guava -->
-        <guava.version>33.6.0-jre</guava.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
-        <commons-lang3.version>3.20.0</commons-lang3.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
-        <org.mapstruct.version>1.6.3</org.mapstruct.version>
-        <!-- Source: https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils -->
-        <plexus-utils.version>4.0.3</plexus-utils.version>
-        <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
-        <kotlin.version>2.3.21</kotlin.version>
-
-        <!-- Sonar Properties        -->
-        <!--suppress XmlUnresolvedReference -->
-        <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
-        <!--suppress CheckTagEmptyBody -->
-        <sonar.login></sonar.login>
-        <!--suppress CheckTagEmptyBody -->
-        <sonar.password></sonar.password>
-        <sonar.projectName>confirmation-statement-api</sonar.projectName>
-        <sonar.projectKey>uk.gov.companieshouse:confirmation-statement-api</sonar.projectKey>
-    </properties>
 
     <dependencies>
 


### PR DESCRIPTION
## Summary

This change updates the project dependency baseline and applies explicit version overrides for known transitive risk areas in `pom.xml`.

### Version upgrades

- Parent POM: `uk.gov.companieshouse:companies-house-parent` `2.1.14` → `2.1.15`
- Internal libraries:
    - `api-sdk-java` `7.0.5` → `7.2.1`
    - `private-api-sdk-java` `7.0.4` → `7.2.1`
    - `api-sdk-manager-java-library` `3.0.24` → `3.0.28`
- BOM / core libraries:
    - `jackson3.version` `3.2.0` → `3.2.1`
    - `com.fasterxml.jackson:jackson-bom` `2.22.0` → `2.22.1`
    - `log4j-bom.version` `2.26.0` → `2.26.1` (and imported via `dependencyManagement`)
    - `io.grpc:grpc-context` `1.82.1` → `1.82.2`

### Added explicit overrides

- Added `com.google.protobuf:protobuf-java` `4.35.1` in `dependencyManagement` (temporary pin until a stable `4.36.x` release is available).
- Added CVE override entries for:
    - `org.apache.tomcat.embed:tomcat-embed-core` `11.0.24`
    - `org.apache.tomcat.embed:tomcat-embed-websocket` `11.0.24`

### Outcome

Dependency versions are now aligned to newer parent/internal baselines, with targeted override controls in place for protobuf and Tomcat transitive dependencies.
